### PR TITLE
chore: comply with Unraid Third Party App Naming and Trademark Policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-The Unraid Management Agent is a Go-based plugin for Unraid that exposes comprehensive system monitoring and control via REST API, WebSockets, and MCP (Model Context Protocol). This is a **third-party community plugin**, not an official Unraid product. It provides a REST API + WebSocket interface as an alternative/complement to the official Unraid GraphQL API.
+Management Agent for Unraid® is a Go-based plugin for Unraid® that exposes comprehensive system monitoring and control via REST API, WebSockets, and MCP (Model Context Protocol). This is a **third-party community plugin**, not an official Unraid® product. It provides a REST API + WebSocket interface as an alternative/complement to the official Unraid® GraphQL API.
+
+> **Trademark Notice:** Unraid® is a registered trademark of Lime Technology, Inc. This application is not affiliated with, endorsed, or sponsored by Lime Technology, Inc.
 
 **Language:** Go 1.25
-**Target Platform:** Linux/amd64 (Unraid OS)
+**Target Platform:** Linux/amd64 (Unraid® OS)
 
 ## Essential Commands
 
@@ -20,7 +22,7 @@ make deps
 # Build for local development (current architecture)
 make local
 
-# Build for Unraid (Linux/amd64)
+# Build for Unraid® (Linux/amd64)
 make release
 
 # Create full plugin package (.tgz)
@@ -52,14 +54,14 @@ make clean
 ./unraid-management-agent boot --port 8043
 ```
 
-### Deployment to Unraid
+### Deployment to Unraid®
 
 Use the provided deployment scripts for building and testing on actual hardware:
 
 ```bash
-# 1. Create config with Unraid SSH credentials
+# 1. Create config with Unraid® SSH credentials
 cp scripts/config.sh.example scripts/config.sh
-# Edit config.sh with actual Unraid server IP, username, and password
+# Edit config.sh with actual Unraid® server IP, username, and password
 
 # 2. Deploy and test
 ./scripts/deploy-plugin.sh
@@ -202,7 +204,7 @@ Execute control operations via `lib.ExecuteShellCommand()`:
 #### 7. Library Utilities (`daemon/lib/`)
 
 - `shell.go`: Execute shell commands with error handling
-- `parser.go`: Parse Unraid-specific file formats (.ini files)
+- `parser.go`: Parse Unraid®-specific file formats (.ini files)
 - `validation.go`: Input validation (CWE-22 path traversal protection)
 - `dmidecode.go`, `ethtool.go`: Hardware info parsing
 
@@ -224,9 +226,9 @@ Coordinates the entire application lifecycle:
 4. **WebSocket Hub** receives event, broadcasts to all clients
 5. **REST endpoint** `/api/v1/system` returns cached `systemCache` data
 
-### Unraid Integration
+### Unraid® Integration
 
-The agent reads from Unraid-specific locations (see `daemon/constants/const.go`):
+The agent reads from Unraid®-specific locations (see `daemon/constants/const.go`):
 
 **Configuration Files:**
 
@@ -243,7 +245,7 @@ The agent reads from Unraid-specific locations (see `daemon/constants/const.go`)
 
 **Binaries:**
 
-- `/usr/local/sbin/mdcmd` - Unraid management command (array operations)
+- `/usr/local/sbin/mdcmd` - Unraid® management command (array operations)
 - `/usr/bin/docker` - Docker CLI
 - `/usr/bin/virsh` - VM management
 - `/usr/sbin/smartctl` - SMART data
@@ -409,7 +411,7 @@ Use `lib.ExecuteShellCommand()` for all shell commands — never use `exec.Comma
 - **Initialization order is critical** — API subscriptions must start before collectors in orchestrator.go
 - **Always use mutex locks** — RLock/RUnlock for cache reads, Lock/Unlock for writes
 - **Always validate user input** — use `lib.Validate*()` functions to prevent injection and path traversal
-- **Test on actual Unraid** — local development differs from production; use deployment scripts
+- **Test on actual Unraid®** — local development differs from production; use deployment scripts
 - **Context cancellation** — respect `ctx.Done()` in goroutines for graceful shutdown
 - **Keep CHANGELOG.md updated** — every change must be documented before release
 

--- a/README.md
+++ b/README.md
@@ -5,29 +5,31 @@
 [![License](https://img.shields.io/github/license/ruaan-deysel/unraid-management-agent)](./LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ruaan-deysel/unraid-management-agent)
 
-# Unraid Management Agent
+# Management Agent for Unraid®
 
-A Go-based plugin for Unraid that exposes comprehensive system monitoring and control via REST API and WebSockets.
+A Go-based plugin for Unraid® that exposes comprehensive system monitoring and control via REST API and WebSockets.
+
+> **Unraid® is a registered trademark of Lime Technology, Inc. This application is not affiliated with, endorsed, or sponsored by Lime Technology, Inc.**
 
 ## ⚠️ Important: Third-Party Plugin Notice
 
-**This is a community-developed third-party plugin and is NOT an official Unraid product.**
+**This is a community-developed third-party plugin and is NOT an official Unraid® product.**
 
-### Relationship to Official Unraid API
+### Relationship to Official Unraid® API
 
-- **Official Unraid API**: Unraid OS 7.2+ includes an official **GraphQL-based API** as part of the core operating system. This is the official API provided and supported by Lime Technology (the creators of Unraid).
+- **Official Unraid® API**: Unraid® OS 7.2+ includes an official **GraphQL-based API** as part of the core operating system. This is the official API provided and supported by Lime Technology, Inc. (the creators of Unraid®).
 
-- **This Plugin**: The Unraid Management Agent is a **separate, independent third-party plugin** that provides a **REST API and WebSocket interface** for system monitoring and control. It is developed and maintained by the community, not by Lime Technology.
+- **This Plugin**: Management Agent for Unraid® is a **separate, independent third-party plugin** that provides a **REST API and WebSocket interface** for system monitoring and control. It is developed and maintained by the community, not by Lime Technology, Inc.
 
 ### Key Differences
 
-| Feature          | Official Unraid API        | This Plugin (Unraid Management Agent)         |
-| ---------------- | -------------------------- | --------------------------------------------- |
-| **Developer**    | Lime Technology (Official) | Community (Third-Party)                       |
-| **API Type**     | GraphQL                    | REST API + WebSocket                          |
-| **Availability** | Built into Unraid OS 7.2+  | Separate plugin installation required         |
-| **Support**      | Official Unraid support    | Community support                             |
-| **Purpose**      | Official system API        | Alternative/complementary monitoring solution |
+| Feature          | Official Unraid® API        | This Plugin (Management Agent for Unraid®)    |
+| ---------------- | --------------------------- | --------------------------------------------- |
+| **Developer**    | Lime Technology (Official)  | Community (Third-Party)                       |
+| **API Type**     | GraphQL                     | REST API + WebSocket                          |
+| **Availability** | Built into Unraid® OS 7.2+  | Separate plugin installation required         |
+| **Support**      | Official Unraid® support    | Community support                             |
+| **Purpose**      | Official system API         | Alternative/complementary monitoring solution |
 
 ### When to Use This Plugin
 
@@ -40,14 +42,14 @@ You might choose this plugin if you:
 
 ### Coexistence with Official API
 
-This plugin **can coexist** with the official Unraid API. They operate independently and do not conflict with each other. You can use both simultaneously if your use case requires it.
+This plugin **can coexist** with the official Unraid® API. They operate independently and do not conflict with each other. You can use both simultaneously if your use case requires it.
 
-### Official Unraid API Documentation
+### Official Unraid® API Documentation
 
-For information about the official Unraid GraphQL API, please refer to:
+For information about the official Unraid® GraphQL API, please refer to:
 
-- [Unraid Official Documentation](https://docs.unraid.net/)
-- Unraid OS 7.2+ release notes and API documentation
+- [Unraid® Official Documentation](https://docs.unraid.net/)
+- Unraid® OS 7.2+ release notes and API documentation
 
 ---
 
@@ -179,7 +181,7 @@ Coordinates the entire application lifecycle:
 
 ## System Requirements and Dependencies
 
-**Important:** The Unraid Management Agent has **NO external plugin dependencies**. It collects data directly from system sources.
+**Important:** Management Agent for Unraid® has **NO external plugin dependencies**. It collects data directly from system sources.
 
 For detailed information, see:
 
@@ -189,13 +191,13 @@ For detailed information, see:
 
 ### Quick Prerequisites
 
-- Unraid 6.9+ (tested on Unraid 7.x)
+- Unraid® 6.9+ (tested on Unraid® 7.x)
 - Port 8043 available (configurable)
 - No other plugins required
 
 ### Via Community Applications (Recommended)
 
-**Coming Soon**: This plugin will be available in the Unraid Community Applications store.
+**Coming Soon**: This plugin will be available in the Unraid® Community Applications store.
 
 For now, you can install manually using the plugin URL:
 
@@ -252,7 +254,7 @@ make package
 
 ## System Compatibility
 
-**Important Notice:** This plugin was developed and tested on a specific Unraid system configuration. While we strive for broad compatibility, **there is a possibility that the plugin may not function correctly on all hardware configurations** due to variations in:
+**Important Notice:** This plugin was developed and tested on a specific Unraid® system configuration. While we strive for broad compatibility, **there is a possibility that the plugin may not function correctly on all hardware configurations** due to variations in:
 
 - **CPU Architectures**: Different CPU models, instruction sets, and architectures (Intel vs AMD, different generations)
 - **Disk Controllers and Storage Devices**: Various RAID controllers, HBA cards, SAS/SATA controllers, NVMe configurations
@@ -271,7 +273,7 @@ make package
 
 This plugin has been developed and tested on the following configuration:
 
-- **Unraid Version**: 7.x
+- **Unraid® Version**: 7.x
 - **Plugin Version**: 2025.11.0
 - **Architecture**: Linux/amd64
 - **Primary Testing**: REST API endpoints, WebSocket events, Docker/VM control operations
@@ -530,9 +532,9 @@ make clean
 
 ### Settings Page
 
-Configure the plugin through the Unraid web UI:
+Configure the plugin through the Unraid® web UI:
 
-1. Navigate to **Settings** → **Unraid Management Agent**
+1. Navigate to **Settings** → **Management Agent for Unraid®**
 2. Adjust settings as needed:
    - **Port**: API server port (default: 8043)
    - **Collection Intervals**: How often each data type is collected
@@ -735,7 +737,7 @@ Hardware: AMD Ryzen 9 5950X, LSI 9300-8i HBA, NVIDIA RTX 3080
 Issue: GPU temperature not detected due to different nvidia-smi output format
 Solution: Added parsing for alternative nvidia-smi XML format
 Testing: Verified GPU metrics endpoint returns correct data, all tests pass
-Unraid Version: 7.2
+Unraid® Version: 7.2
 ```
 
 ### Why Community Contributions Matter
@@ -752,10 +754,16 @@ As a single maintainer, it's challenging to:
 
 - 🔧 **Hardware-Specific Fixes**: Support for different disk controllers, GPU models, UPS brands
 - 📊 **Data Collection Improvements**: Better parsing of system commands for different hardware
-- 🧪 **Testing**: Testing on different Unraid versions and hardware configurations
+- 🧪 **Testing**: Testing on different Unraid® versions and hardware configurations
 - 📝 **Documentation**: Improving docs, adding examples, documenting edge cases
 - 🐛 **Bug Fixes**: Fixing issues you encounter on your system
 - ✨ **New Features**: Adding support for additional hardware or metrics
+
+## Trademarks
+
+Unraid® is a registered trademark of Lime Technology, Inc. This application is not affiliated with, endorsed, or sponsored by Lime Technology, Inc.
+
+This project follows Unraid's [Third Party App Naming and Trademark Policy](https://unraid.net/policies).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 # Documentation
 
-Welcome to the Unraid Management Agent documentation. This directory contains comprehensive guides for installation, API usage, integration, and development.
+Welcome to the Management Agent for Unraid® documentation. This directory contains comprehensive guides for installation, API usage, integration, and development.
+
+> **Trademark Notice:** Unraid® is a registered trademark of Lime Technology, Inc. This application is not affiliated with, endorsed, or sponsored by Lime Technology, Inc.
 
 ## 📚 Table of Contents
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,14 +1,16 @@
 # Installation Guide
 
-Complete installation instructions for the Unraid Management Agent.
+Complete installation instructions for Management Agent for Unraid®.
+
+> **Trademark Notice:** Unraid® is a registered trademark of Lime Technology, Inc. This application is not affiliated with, endorsed, or sponsored by Lime Technology, Inc.
 
 ## Overview
 
-The Unraid Management Agent is installed as a **Community Applications** plugin and provides a REST API, WebSocket events, MQTT publishing, Prometheus metrics, and Model Context Protocol (MCP) integration for monitoring and controlling your Unraid server.
+Management Agent for Unraid® is installed as a **Community Applications** plugin and provides a REST API, WebSocket events, MQTT publishing, Prometheus metrics, and Model Context Protocol (MCP) integration for monitoring and controlling your Unraid® server.
 
 ## Prerequisites
 
-- Unraid OS 6.8.0 or newer (6.12.0+ recommended)
+- Unraid® OS 6.8.0 or newer (6.12.0+ recommended)
 - Community Applications plugin installed
 - Network connectivity
 - Basic understanding of REST APIs (optional)
@@ -17,9 +19,9 @@ The Unraid Management Agent is installed as a **Community Applications** plugin 
 
 ### Method 1: Community Applications (Recommended)
 
-1. **Open Unraid Web UI** → **Plugins** → **Community Applications**
+1. **Open Unraid® Web UI** → **Plugins** → **Community Applications**
 
-2. **Search** for "Unraid Management Agent"
+2. **Search** for "Management Agent for Unraid"
 
 3. **Click Install** and wait for completion
 
@@ -59,10 +61,10 @@ For developers or testing:
 git clone https://github.com/ruaan-deysel/unraid-management-agent.git
 cd unraid-management-agent
 
-# Build for Unraid (Linux/amd64)
+# Build for Unraid® (Linux/amd64)
 make release
 
-# Copy to Unraid
+# Copy to Unraid®
 scp build/unraid-management-agent root@YOUR_UNRAID_IP:/usr/local/bin/
 
 # Set permissions
@@ -113,7 +115,7 @@ The API listens on **port 8043**. To access from other machines:
 curl http://YOUR_UNRAID_IP:8043/api/v1/health
 ```
 
-**Firewall**: Port 8043 should be accessible by default on Unraid.
+**Firewall**: Port 8043 should be accessible by default on Unraid®.
 
 ### 4. Security Considerations
 
@@ -181,7 +183,7 @@ wget https://github.com/ruaan-deysel/unraid-management-agent/releases/latest/dow
 ### Via Web UI
 
 1. **Plugins** → **Installed Plugins**
-2. Find "Unraid Management Agent"
+2. Find "Management Agent for Unraid®"
 3. Click **Uninstall**
 
 ### Manual Removal
@@ -253,7 +255,7 @@ ls -la /var/log/unraid-management-agent.log
 
 - **GitHub Issues**: https://github.com/ruaan-deysel/unraid-management-agent/issues
 - **Documentation**: https://github.com/ruaan-deysel/unraid-management-agent/tree/main/docs
-- **Community**: Unraid Forums
+- **Community**: Unraid® Forums
 
 ---
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -1,12 +1,14 @@
 # Quick Start Guide
 
-Get up and running with the Unraid Management Agent in under 5 minutes.
+Get up and running with Management Agent for Unraid® in minutes.
+
+> **Trademark Notice:** Unraid® is a registered trademark of Lime Technology, Inc. This application is not affiliated with, endorsed, or sponsored by Lime Technology, Inc.
 
 ## Installation
 
 ### Via Plugin URL (Recommended)
 
-1. Open Unraid Web UI
+1. Open Unraid® Web UI
 2. Navigate to **Plugins** → **Install Plugin**
 3. Paste plugin URL:
    ```
@@ -82,7 +84,7 @@ curl http://localhost:8043/api/v1/disks | jq
 const ws = new WebSocket('ws://YOUR_UNRAID_IP:8043/api/v1/ws');
 
 ws.onopen = () => {
-  console.log('Connected to Unraid Management Agent');
+  console.log('Connected to Management Agent for Unraid®');
 };
 
 ws.onmessage = (event) => {
@@ -107,7 +109,7 @@ def on_message(ws, message):
     print(f"Data: {data['data']}")
 
 def on_open(ws):
-    print("Connected to Unraid Management Agent")
+    print("Connected to Management Agent for Unraid®")
 
 ws = websocket.WebSocketApp(
     "ws://YOUR_UNRAID_IP:8043/api/v1/ws",
@@ -171,13 +173,13 @@ curl http://localhost:8043/metrics
 
 ### Change Port
 
-1. Navigate to **Settings** → **Unraid Management Agent**
+1. Navigate to **Settings** → **Management Agent for Unraid®**
 2. Change **Port** setting
 3. Click **Apply** (service restarts automatically)
 
 ### Adjust Collection Intervals
 
-1. Navigate to **Settings** → **Unraid Management Agent**
+1. Navigate to **Settings** → **Management Agent for Unraid®**
 2. Adjust intervals for each collector type
 3. Click **Apply**
 
@@ -225,7 +227,7 @@ netstat -tulpn | grep 8043
 
 - **Issues**: [GitHub Issues](https://github.com/ruaan-deysel/unraid-management-agent/issues)
 - **Documentation**: [Full Documentation](../README.md)
-- **Community**: Unraid Community Forums
+- **Community**: Unraid® Community Forums
 
 ---
 

--- a/meta/template/unraid-management-agent.plg
+++ b/meta/template/unraid-management-agent.plg
@@ -53,9 +53,12 @@
 </CHANGES>
 
 <!--
-Unraid Management Agent - REST API and WebSocket server for Home Assistant integration.
+Management Agent for Unraid® - REST API and WebSocket server for Home Assistant integration.
 
-Exposes comprehensive Unraid system monitoring and control via REST API and WebSockets.
+Exposes comprehensive Unraid® system monitoring and control via REST API and WebSockets.
+
+Unraid® is a registered trademark of Lime Technology, Inc.
+This application is not affiliated with, endorsed, or sponsored by Lime Technology, Inc.
 -->
 
 <!-- Get the plugin bundle -->

--- a/unraid-management-agent.plg
+++ b/unraid-management-agent.plg
@@ -16,7 +16,7 @@
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" icon="server" min="6.9.0" pluginURL="&pluginURL;" support="&supportURL;">
 
 <DESCRIPTION>
-This Unraid plugin provides REST API and WebSocket interfaces for real-time system monitoring, Docker/VM control, and comprehensive hardware metrics.
+Management Agent for Unraid® - REST API and WebSocket interfaces for real-time system monitoring, Docker/VM control, and comprehensive hardware metrics. Unraid® is a trademark of Lime Technology, Inc. Not affiliated.
 </DESCRIPTION>
 
 <CHANGES>
@@ -53,10 +53,13 @@ This Unraid plugin provides REST API and WebSocket interfaces for real-time syst
 </CHANGES>
 
 <!--
-Unraid Management Agent - REST API and WebSocket server for comprehensive system monitoring and control.
+Management Agent for Unraid® - REST API and WebSocket server for comprehensive system monitoring and control.
 
-This plugin provides a REST API and WebSocket interface for monitoring and controlling your Unraid server.
+This plugin provides a REST API and WebSocket interface for monitoring and controlling your Unraid® server.
 Perfect for Home Assistant integration, custom dashboards, or automation scripts.
+
+Unraid® is a registered trademark of Lime Technology, Inc.
+This application is not affiliated with, endorsed, or sponsored by Lime Technology, Inc.
 
 Features:
 - 20+ REST API endpoints
@@ -70,7 +73,7 @@ Features:
 - Automatic log rotation
 
 Requirements:
-- Unraid 6.9+ (tested on Unraid 7.x)
+- Unraid® 6.9+ (tested on Unraid® 7.x)
 - Port 8043 available (configurable)
 
 Support:
@@ -96,20 +99,20 @@ if [ -f /etc/unraid-version ]; then
     if [ "$major_version" -lt 6 ] || ([ "$major_version" -eq 6 ] && [ "$minor_version" -lt 9 ]); then
         echo ""
         echo "========================================="
-        echo " ERROR: Incompatible Unraid Version"
+        echo " ERROR: Incompatible Unraid® Version"
         echo "========================================="
         echo ""
-        echo "This plugin requires Unraid 6.9.0 or higher."
+        echo "This plugin requires Unraid® 6.9.0 or higher."
         echo "Your current version: $version"
         echo ""
-        echo "Please upgrade your Unraid system before installing this plugin."
+        echo "Please upgrade your Unraid® system before installing this plugin."
         echo ""
         exit 1
     fi
 
-    echo "✓ Unraid version check passed (version: $version)"
+    echo "✓ Unraid® version check passed (version: $version)"
 else
-    echo "⚠ Warning: Could not verify Unraid version"
+    echo "⚠ Warning: Could not verify Unraid® version"
     echo "  Proceeding with installation..."
 fi
 
@@ -128,7 +131,7 @@ exit 0
 <FILE Name="/boot/config/plugins/&name;/config.cfg">
 <INLINE>
 <![CDATA[
-# Unraid Management Agent Configuration
+# Management Agent for Unraid® Configuration
 # This file is automatically created if it doesn't exist
 
 # Service configuration


### PR DESCRIPTION
- Rename display name from "Unraid Management Agent" to "Management Agent for Unraid®"
- Add required trademark attribution to README.md, CLAUDE.md, and documentation
- Add trademark notice to plugin description and comments in .plg files
- Add ® symbol to prominent Unraid mentions throughout documentation
- Add Trademarks section to README.md with policy reference

Changes follow Unraid's policy effective October 1, 2025:
- Use "[YourApp] for Unraid®" naming format instead of "Unraid [YourApp]"
- Include required disclaimer about trademark ownership and non-affiliation

https://claude.ai/code/session_01LAtGB1ca2H14B8MjVrPv8f