### PR TITLE
Fix VM resume/start when pmsuspended (Windows sleep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **VM cannot be resumed/started via API when pmsuspended** (GitHub Issue #65):
+  - Fixed `POST /api/v1/vm/{name}/resume` and `POST /api/v1/vm/{name}/start` failing when VM is in pmsuspended state (Windows sleep)
+  - libvirt DomainResume fails with "domain is pmsuspended"; DomainCreate fails with "domain is already running"
+  - VM controller now detects pmsuspended state and uses `virsh dompmwakeup` to wake the VM, equivalent to pressing Start in Unraid web UI
+
 ## [2026.02.01] - 2026-02-14
 
 ### Added


### PR DESCRIPTION
# Merge Request: Fix VM resume/start when pmsuspended (Windows sleep)

## Description

Fixes VM resume/start when the VM is in **pmsuspended** state (e.g., Windows sleep). When a Windows VM goes to sleep, Unraid suspends it for power saving—the VM enters libvirt `pmsuspended` state. In this state, `POST /api/v1/vm/{name}/resume` failed with "domain is pmsuspended" and `POST /api/v1/vm/{name}/start` failed with "domain is already running". This PR detects pmsuspended state and uses `virsh dompmwakeup` to wake the VM, equivalent to pressing Start in the Unraid web UI.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Hardware compatibility fix
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Test additions/improvements

## Related Issues

Fixes #65

## Hardware Configuration (if applicable)

- **Unraid Version:** 7.2.4 (from issue)

## Changes Made

- Added `pmWakeup()` in `daemon/services/controllers/vm.go` that runs `virsh dompmwakeup` for pmsuspended VMs
- Modified `Start()` to check domain state; if pmsuspended, calls `pmWakeup()` instead of `DomainCreate`
- Modified `Resume()` to check domain state; if pmsuspended, calls `pmWakeup()` instead of `DomainResume`
- Updated `CHANGELOG.md` with the fix

## Testing Performed

- [x] Unit tests pass (`make test`)
- [ ] Added new tests for new functionality
- [x] Tested on actual Unraid system
- [x] Verified affected API endpoints work correctly
- [ ] Tested WebSocket events (if applicable)
- [ ] Tested with debug logging enabled
- [x] Regression testing (ensured existing functionality still works)

### Test Results

**API Endpoints Tested:**
- `GET /api/v1/vm/{name}` - confirms VM shows `state: "suspended"` when pmsuspended
- `POST /api/v1/vm/{name}/resume` - successfully wakes pmsuspended VMs
- `POST /api/v1/vm/{name}/start` - successfully wakes pmsuspended VMs

**Test Output/Results:**

```bash
# Before fix: resume failed
curl -X POST http://unraid-ip:8043/api/v1/vm/Windows10/resume
# {"success": false, "message": "Failed to resume VM: domain is pmsuspended"}

# After fix: resume succeeds
curl -X POST http://unraid-ip:8043/api/v1/vm/Windows10/resume
# {"success": true, "message": "VM resumed"}
# VM returns to running state
```

## Documentation

- [x] Code comments added/updated (inline comments in vm.go)
- [ ] README.md updated (if needed)
- [ ] CLAUDE.md updated (if architecture changed)
- [ ] CONTRIBUTING.md updated (if contribution process changed)
- [ ] API documentation updated (rest-api.md, websocket-events.md, websocket-structure.md)
- [x] No documentation needed

## Breaking Changes

**Breaking Changes:** None

**Migration Guide:** N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] No sensitive information (API keys, passwords, personal data) is included

## Additional Notes

The fix uses `virsh dompmwakeup` since the go-libvirt library doesn't expose `DomainPMWakeup` in its API. The VM controller uses libvirt for other operations and `lib.ExecCommand` for virsh—consistent with other controllers (e.g., array controller uses `mdcmd`).
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue preventing VMs in a pmsuspended state (Windows sleep mode) from being resumed or started through the API. The system now correctly wakes suspended VMs, bringing API behaviour in line with the Start button in the Unraid UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->