### PR TITLE
fix(collectors): convert share sizes from KiB to bytes

### DIFF
--- a/daemon/services/collectors/share.go
+++ b/daemon/services/collectors/share.go
@@ -109,6 +109,8 @@ func (c *ShareCollector) Collect() {
 }
 
 func (c *ShareCollector) collectShares() ([]dto.ShareInfo, error) {
+	const kibToBytes uint64 = 1024
+
 	logger.Debug("Share: Starting collection from %s", constants.SharesIni)
 	var shares []dto.ShareInfo
 
@@ -170,15 +172,15 @@ func (c *ShareCollector) collectShares() ([]dto.ShareInfo, error) {
 				currentShare.Name = value
 			case "size":
 				if size, err := strconv.ParseUint(value, 10, 64); err == nil {
-					currentShare.Total = size
+					currentShare.Total = size * kibToBytes // shares.ini stores size in KiB (1024-byte blocks)
 				}
 			case "free":
 				if free, err := strconv.ParseUint(value, 10, 64); err == nil {
-					currentShare.Free = free
+					currentShare.Free = free * kibToBytes // shares.ini stores free in KiB (1024-byte blocks)
 				}
 			case "used":
 				if used, err := strconv.ParseUint(value, 10, 64); err == nil {
-					currentShare.Used = used
+					currentShare.Used = used * kibToBytes // shares.ini stores used in KiB (1024-byte blocks)
 				}
 			// Cache settings from shares.ini (Issue #53)
 			case "useCache":


### PR DESCRIPTION
## Problem

`shares.ini` (at `/var/local/emhttp/shares.ini`) stores `used`, `free`, and `size` values in KiB (1024-byte blocks), matching `df -k` output. The share collector was storing these raw values directly into fields named `used_bytes`/`free_bytes`/`total_bytes` without any conversion, so the values were semantically wrong — KiB stored in byte fields.

This caused Home Assistant to display share sizes ~1000x smaller than actual (e.g. a 35 TB share appeared as ~35 GB).

## Fix

Apply `* 1024` when parsing `size`, `free`, and `used` from `shares.ini` — the same conversion already present in `disk.go` for `disks.ini`, which has an explicit comment noting the same issue.

## Verification

Confirmed on a live Unraid host by comparing raw `shares.ini` values against `df -k` output — the numbers match exactly, confirming the values are in KiB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected share storage capacity reporting: total, free and used metrics are now converted from kibibytes to bytes, producing accurate and consistent storage statistics across shared resources. This improves reliability of displayed capacity and aids better storage planning and monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->