### PR TITLE
fix(ui): fix select and warning colours in dark mode

### DIFF
--- a/meta/plugin/unraid-management-agent.page
+++ b/meta/plugin/unraid-management-agent.page
@@ -174,14 +174,14 @@ function intervalOptions($selected, $type = 'standard') {
     width: 110px;
     padding: 3px 6px;
     font-size: 12px;
-    border: 1px solid var(--gray-300, #ccc);
+    border: 1px solid var(--input-border-color, #ccc);
     border-radius: 3px;
-    background-color: var(--gray-000, #fff);
-    color: inherit;
+    background-color: var(--input-bg-color, transparent);
+    color: var(--text-color, inherit);
 }
 .uma-power-warning {
-    background-color: var(--yellow-100, #fff3cd);
-    border: 1px solid var(--orange-200, #ffc107);
+    background-color: rgba(255, 211, 36, 0.12);
+    border: 1px solid var(--orange-200, #ff9900);
     border-radius: 5px;
     padding: 10px;
     margin-top: 15px;
@@ -189,12 +189,12 @@ function intervalOptions($selected, $type = 'standard') {
     color: inherit;
 }
 .uma-interval-select option[value="0"] {
-    color: var(--red-500, #d32f2f);
+    color: var(--red-500, #ff3300);
     font-weight: bold;
 }
 .uma-interval-select.is-disabled {
-    border-color: var(--red-500, #d32f2f);
-    background-color: var(--red-100, #ffebee);
+    border-color: var(--red-500, #ff3300);
+    background-color: rgba(255, 51, 0, 0.08);
 }
 .uma-toggle-switch {
     position: relative;


### PR DESCRIPTION
Fixes #55

## Root cause

`--gray-000` is defined in Unraid's global colour palette as `var(--white)` (`#ffffff`) and is **never overridden** by any theme — including dark mode. So `.uma-interval-select` always had a white background regardless of theme. In dark mode, where `--text-color` is a light colour, this produced invisible text (light on white).

The same issue affected the disabled-select and power-warning backgrounds, which used hardcoded light-colour fallbacks (`#ffebee`, `#fff3cd`).

## Fix

Replace the hardcoded values with Unraid's own Dynamix theme variables, following the same pattern used by `default-base.css` for all native inputs:

| Property | Before | After |
|---|---|---|
| `background-color` (select) | `var(--gray-000, #fff)` | `var(--input-bg-color, transparent)` |
| `color` (select) | `inherit` | `var(--text-color, inherit)` |
| `border-color` (select) | `var(--gray-300, #ccc)` | `var(--input-border-color, #ccc)` |
| `background-color` (disabled) | `var(--red-100, #ffebee)` | `rgba(255, 51, 0, 0.08)` |
| `background-color` (warning) | `var(--yellow-100, #fff3cd)` | `rgba(255, 211, 36, 0.12)` |

Semi-transparent `rgba` values for the disabled state and warning box ensure they work on any background colour across all themes.