### PR TITLE
fix(mqtt): use power_watts instead of nominal_power_watts for UPS Power Draw sensor

### DIFF
--- a/daemon/services/mqtt/discovery.go
+++ b/daemon/services/mqtt/discovery.go
@@ -474,7 +474,7 @@ func (c *Client) publishUPSDiscovery() {
 	c.publishHAEntity(haEntityOpts{
 		entityType: "sensor", stateTopic: topic,
 		id: "ups_power", name: "UPS: Power Draw", unit: "W",
-		icon: "mdi:lightning-bolt", template: "{{ value_json.nominal_power_watts | default(0) | round(0) }}",
+		icon: "mdi:lightning-bolt", template: "{{ value_json.power_watts | default(0) | round(0) }}",
 		deviceClass: "power", stateClass: "measurement",
 	})
 	c.publishHAEntity(haEntityOpts{


### PR DESCRIPTION
## Problem

The `UPS: Power Draw` Home Assistant sensor was always showing a constant value and never updating.

The MQTT discovery template was referencing `value_json.nominal_power_watts` — the fixed rated capacity of the UPS (e.g. "1000W" always). The actual calculated power draw is in `value_json.power_watts`, which is computed as `nominal_power_watts × load_percent / 100` and updates with each collection cycle.

## Fix

One-line template change: `nominal_power_watts` → `power_watts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected UPS power reporting in Home Assistant integration to display actual power consumption instead of nominal capacity rating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->