### PR TITLE
feat(mqtt): wire 7 missing collector topics to MQTT and add full HA discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MQTT: 7 previously missing event types now published** — NUT UPS (`nut/status`),
+  hardware info (`hardware`), registration (`registration`), unassigned devices
+  (`unassigned/devices`), ZFS datasets (`zfs/datasets`), ZFS snapshots
+  (`zfs/snapshots`), and ZFS ARC stats (`zfs/arc`)
+- **MQTT: Full Home Assistant MQTT discovery for all 7 new data types** — NUT UPS metrics
+  (battery, load, voltage, runtime, model), hardware diagnostics (BIOS, baseboard, CPU speed,
+  memory slots), registration state/validity/expiry, per-device unassigned disk sensors,
+  per-dataset ZFS usage/compression/readonly, snapshot count/total size, ARC size/hit ratio,
+  and L2ARC size/hit ratio
+- **MQTT: `MQTTTopics` DTO and `/api/v1/mqtt/topics` endpoint** updated with 7 new topic paths
+
 ## [2026.03.03] - 2026-03-18
 
 ### Fixed

--- a/daemon/dto/mqtt.go
+++ b/daemon/dto/mqtt.go
@@ -123,6 +123,13 @@ type MQTTTopics struct {
 	Notification string `json:"notifications" example:"unraid/notifications"`
 	ZFSPools     string `json:"zfs_pools" example:"unraid/zfs/pools"`
 	Availability string `json:"availability" example:"unraid/availability"`
+	NUT          string `json:"nut" example:"unraid/nut/status"`
+	Hardware     string `json:"hardware" example:"unraid/hardware"`
+	Registration string `json:"registration" example:"unraid/registration"`
+	Unassigned   string `json:"unassigned" example:"unraid/unassigned/devices"`
+	ZFSDatasets  string `json:"zfs_datasets" example:"unraid/zfs/datasets"`
+	ZFSSnapshots string `json:"zfs_snapshots" example:"unraid/zfs/snapshots"`
+	ZFSARC       string `json:"zfs_arc" example:"unraid/zfs/arc"`
 }
 
 // MQTTEnableRequest represents a request to enable/disable MQTT.

--- a/daemon/dto/mqtt_test.go
+++ b/daemon/dto/mqtt_test.go
@@ -508,6 +508,13 @@ func TestMQTTTopics(t *testing.T) {
 		Shares:       "unraid/shares",
 		Notification: "unraid/notifications",
 		Availability: "unraid/availability",
+		NUT:          "unraid/nut/status",
+		Hardware:     "unraid/hardware",
+		Registration: "unraid/registration",
+		Unassigned:   "unraid/unassigned/devices",
+		ZFSDatasets:  "unraid/zfs/datasets",
+		ZFSSnapshots: "unraid/zfs/snapshots",
+		ZFSARC:       "unraid/zfs/arc",
 	}
 
 	data, err := json.Marshal(topics)
@@ -555,6 +562,27 @@ func TestMQTTTopics(t *testing.T) {
 	}
 	if decoded.Availability != topics.Availability {
 		t.Errorf("Availability = %q, want %q", decoded.Availability, topics.Availability)
+	}
+	if decoded.NUT != topics.NUT {
+		t.Errorf("NUT = %q, want %q", decoded.NUT, topics.NUT)
+	}
+	if decoded.Hardware != topics.Hardware {
+		t.Errorf("Hardware = %q, want %q", decoded.Hardware, topics.Hardware)
+	}
+	if decoded.Registration != topics.Registration {
+		t.Errorf("Registration = %q, want %q", decoded.Registration, topics.Registration)
+	}
+	if decoded.Unassigned != topics.Unassigned {
+		t.Errorf("Unassigned = %q, want %q", decoded.Unassigned, topics.Unassigned)
+	}
+	if decoded.ZFSDatasets != topics.ZFSDatasets {
+		t.Errorf("ZFSDatasets = %q, want %q", decoded.ZFSDatasets, topics.ZFSDatasets)
+	}
+	if decoded.ZFSSnapshots != topics.ZFSSnapshots {
+		t.Errorf("ZFSSnapshots = %q, want %q", decoded.ZFSSnapshots, topics.ZFSSnapshots)
+	}
+	if decoded.ZFSARC != topics.ZFSARC {
+		t.Errorf("ZFSARC = %q, want %q", decoded.ZFSARC, topics.ZFSARC)
 	}
 }
 

--- a/daemon/services/mqtt/client.go
+++ b/daemon/services/mqtt/client.go
@@ -314,6 +314,13 @@ func (c *Client) GetTopics() *dto.MQTTTopics {
 		Notification: c.buildTopic("notifications"),
 		ZFSPools:     c.buildTopic("zfs/pools"),
 		Availability: c.buildTopic("availability"),
+		NUT:          c.buildTopic("nut/status"),
+		Hardware:     c.buildTopic("hardware"),
+		Registration: c.buildTopic("registration"),
+		Unassigned:   c.buildTopic("unassigned/devices"),
+		ZFSDatasets:  c.buildTopic("zfs/datasets"),
+		ZFSSnapshots: c.buildTopic("zfs/snapshots"),
+		ZFSARC:       c.buildTopic("zfs/arc"),
 	}
 }
 
@@ -424,6 +431,66 @@ func (c *Client) PublishZFSPools(pools []dto.ZFSPool) error {
 	// Publish per-pool topics and HA discovery
 	go c.publishZFSDiscovery(pools)
 	return err
+}
+
+// PublishNUTStatus publishes NUT UPS status to MQTT.
+func (c *Client) PublishNUTStatus(data *dto.NUTResponse) error {
+	if !c.shouldPublish() {
+		return nil
+	}
+	return c.publishJSON(c.buildTopic("nut/status"), data)
+}
+
+// PublishHardwareInfo publishes hardware information to MQTT.
+func (c *Client) PublishHardwareInfo(info *dto.HardwareInfo) error {
+	if !c.shouldPublish() {
+		return nil
+	}
+	return c.publishJSON(c.buildTopic("hardware"), info)
+}
+
+// PublishRegistration publishes registration/license information to MQTT.
+func (c *Client) PublishRegistration(reg *dto.Registration) error {
+	if !c.shouldPublish() {
+		return nil
+	}
+	return c.publishJSON(c.buildTopic("registration"), reg)
+}
+
+// PublishUnassignedDevices publishes unassigned device information to MQTT.
+func (c *Client) PublishUnassignedDevices(list *dto.UnassignedDeviceList) error {
+	if !c.shouldPublish() {
+		return nil
+	}
+	err := c.publishJSON(c.buildTopic("unassigned/devices"), list)
+	go c.publishUnassignedDiscovery(list)
+	return err
+}
+
+// PublishZFSDatasets publishes ZFS dataset information to MQTT.
+func (c *Client) PublishZFSDatasets(datasets []dto.ZFSDataset) error {
+	if !c.shouldPublish() {
+		return nil
+	}
+	err := c.publishJSON(c.buildTopic("zfs/datasets"), datasets)
+	go c.publishZFSDatasetDiscovery(datasets)
+	return err
+}
+
+// PublishZFSSnapshots publishes ZFS snapshot list to MQTT.
+func (c *Client) PublishZFSSnapshots(snapshots []dto.ZFSSnapshot) error {
+	if !c.shouldPublish() {
+		return nil
+	}
+	return c.publishJSON(c.buildTopic("zfs/snapshots"), snapshots)
+}
+
+// PublishZFSARCStats publishes ZFS ARC statistics to MQTT.
+func (c *Client) PublishZFSARCStats(stats dto.ZFSARCStats) error {
+	if !c.shouldPublish() {
+		return nil
+	}
+	return c.publishJSON(c.buildTopic("zfs/arc"), stats)
 }
 
 // PublishCustom publishes a custom message to the specified topic.

--- a/daemon/services/mqtt/client_coverage_test.go
+++ b/daemon/services/mqtt/client_coverage_test.go
@@ -201,6 +201,13 @@ func TestPerItemDiscovery_NotConnected(t *testing.T) {
 	client.publishShareDiscovery([]dto.ShareInfo{{Name: "Media"}})
 	// ZFS
 	client.publishZFSDiscovery([]dto.ZFSPool{{Name: "tank", Health: "ONLINE"}})
+	// Unassigned
+	client.publishUnassignedDiscovery(&dto.UnassignedDeviceList{
+		Devices: []dto.UnassignedDevice{{Device: "sdc", Model: "WD Black",
+			Partitions: []dto.UnassignedPartition{{PartitionNumber: 1, Label: "Data"}}}},
+	})
+	// ZFS Datasets
+	client.publishZFSDatasetDiscovery([]dto.ZFSDataset{{Name: "tank/media"}})
 
 	if client.IsConnected() {
 		t.Error("client should not be connected")
@@ -344,6 +351,15 @@ func TestPublishMethodsWithEnabledButNotConnected(t *testing.T) {
 		{"PublishShares", func() error { return client.PublishShares([]dto.ShareInfo{}) }},
 		{"PublishNotifications", func() error { return client.PublishNotifications(&dto.NotificationList{}) }},
 		{"PublishZFSPools", func() error { return client.PublishZFSPools([]dto.ZFSPool{}) }},
+		{"PublishNUTStatus", func() error { return client.PublishNUTStatus(&dto.NUTResponse{}) }},
+		{"PublishHardwareInfo", func() error { return client.PublishHardwareInfo(&dto.HardwareInfo{}) }},
+		{"PublishRegistration", func() error { return client.PublishRegistration(&dto.Registration{}) }},
+		{"PublishUnassignedDevices", func() error {
+			return client.PublishUnassignedDevices(&dto.UnassignedDeviceList{})
+		}},
+		{"PublishZFSDatasets", func() error { return client.PublishZFSDatasets([]dto.ZFSDataset{}) }},
+		{"PublishZFSSnapshots", func() error { return client.PublishZFSSnapshots([]dto.ZFSSnapshot{}) }},
+		{"PublishZFSARCStats", func() error { return client.PublishZFSARCStats(dto.ZFSARCStats{}) }},
 	}
 
 	for _, tt := range tests {

--- a/daemon/services/mqtt/client_test.go
+++ b/daemon/services/mqtt/client_test.go
@@ -227,6 +227,13 @@ func TestClientGetTopics(t *testing.T) {
 		{"Shares", topics.Shares, "unraid/shares"},
 		{"Notification", topics.Notification, "unraid/notifications"},
 		{"Availability", topics.Availability, "unraid/availability"},
+		{"NUT", topics.NUT, "unraid/nut/status"},
+		{"Hardware", topics.Hardware, "unraid/hardware"},
+		{"Registration", topics.Registration, "unraid/registration"},
+		{"Unassigned", topics.Unassigned, "unraid/unassigned/devices"},
+		{"ZFSDatasets", topics.ZFSDatasets, "unraid/zfs/datasets"},
+		{"ZFSSnapshots", topics.ZFSSnapshots, "unraid/zfs/snapshots"},
+		{"ZFSARC", topics.ZFSARC, "unraid/zfs/arc"},
 	}
 
 	for _, tc := range testCases {
@@ -425,6 +432,55 @@ func TestPublishMethodsWithoutConnection(t *testing.T) {
 		err := client.PublishNotifications(&dto.NotificationList{})
 		if err != nil {
 			t.Errorf("PublishNotifications() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("PublishNUTStatus", func(t *testing.T) {
+		err := client.PublishNUTStatus(&dto.NUTResponse{})
+		if err != nil {
+			t.Errorf("PublishNUTStatus() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("PublishHardwareInfo", func(t *testing.T) {
+		err := client.PublishHardwareInfo(&dto.HardwareInfo{})
+		if err != nil {
+			t.Errorf("PublishHardwareInfo() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("PublishRegistration", func(t *testing.T) {
+		err := client.PublishRegistration(&dto.Registration{})
+		if err != nil {
+			t.Errorf("PublishRegistration() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("PublishUnassignedDevices", func(t *testing.T) {
+		err := client.PublishUnassignedDevices(&dto.UnassignedDeviceList{})
+		if err != nil {
+			t.Errorf("PublishUnassignedDevices() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("PublishZFSDatasets", func(t *testing.T) {
+		err := client.PublishZFSDatasets([]dto.ZFSDataset{})
+		if err != nil {
+			t.Errorf("PublishZFSDatasets() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("PublishZFSSnapshots", func(t *testing.T) {
+		err := client.PublishZFSSnapshots([]dto.ZFSSnapshot{})
+		if err != nil {
+			t.Errorf("PublishZFSSnapshots() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("PublishZFSARCStats", func(t *testing.T) {
+		err := client.PublishZFSARCStats(dto.ZFSARCStats{})
+		if err != nil {
+			t.Errorf("PublishZFSARCStats() error = %v, want nil", err)
 		}
 	})
 }

--- a/daemon/services/mqtt/discovery.go
+++ b/daemon/services/mqtt/discovery.go
@@ -200,6 +200,11 @@ func (c *Client) publishHADiscovery() {
 	c.publishNotificationDiscovery()
 	c.publishServiceDiscovery()
 	c.publishSystemControlDiscovery()
+	c.publishNUTDiscovery()
+	c.publishHardwareDiscovery()
+	c.publishRegistrationDiscovery()
+	c.publishZFSSnapshotDiscovery()
+	c.publishZFSARCDiscovery()
 
 	logger.Success("MQTT: Home Assistant discovery published")
 }
@@ -1390,6 +1395,391 @@ func (c *Client) publishZFSEntities(topic, prefix, displayName string) []string 
 	})
 
 	return ids
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// NUT UPS
+// ──────────────────────────────────────────────────────────────────────────────
+
+// publishNUTDiscovery publishes HA discovery for NUT UPS metrics.
+// NUTResponse.Status is a pointer — templates use | default() guards for nil safety.
+func (c *Client) publishNUTDiscovery() {
+	topic := c.buildTopic("nut/status")
+	c.publishHAEntity(haEntityOpts{
+		entityType: "binary_sensor", stateTopic: topic,
+		id: "nut_connected", name: "NUT: UPS Connected",
+		icon:        "mdi:battery-charging",
+		template:    "{{ 'ON' if value_json.status.connected | default(false) else 'OFF' }}",
+		deviceClass: "connectivity",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "nut_status", name: "NUT: UPS Status",
+		icon:     "mdi:battery-charging",
+		template: "{{ value_json.status.status | default('unknown') }}",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "nut_battery_charge", name: "NUT: Battery Charge", unit: "%",
+		icon:        "mdi:battery",
+		template:    "{{ value_json.status.battery_charge_percent | default(0) | round(0) }}",
+		deviceClass: "battery", stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "nut_battery_runtime", name: "NUT: Battery Runtime", unit: "s",
+		icon:        "mdi:clock-outline",
+		template:    "{{ value_json.status.battery_runtime_seconds | default(0) }}",
+		deviceClass: "duration", stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "nut_load", name: "NUT: Load", unit: "%",
+		icon:       "mdi:gauge",
+		template:   "{{ value_json.status.load_percent | default(0) | round(1) }}",
+		stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "nut_realpower", name: "NUT: Real Power", unit: "W",
+		icon:        "mdi:lightning-bolt",
+		template:    "{{ value_json.status.realpower_watts | default(0) | round(0) }}",
+		deviceClass: "power", stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "nut_input_voltage", name: "NUT: Input Voltage", unit: "V",
+		icon:        "mdi:sine-wave",
+		template:    "{{ value_json.status.input_voltage | default(0) | round(1) }}",
+		deviceClass: "voltage", stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "nut_output_voltage", name: "NUT: Output Voltage", unit: "V",
+		icon:        "mdi:sine-wave",
+		template:    "{{ value_json.status.output_voltage | default(0) | round(1) }}",
+		deviceClass: "voltage", stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "nut_model", name: "NUT: UPS Model",
+		icon:           "mdi:battery-charging",
+		template:       "{{ value_json.status.model | default('') }}",
+		entityCategory: "diagnostic",
+	})
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hardware Info
+// ──────────────────────────────────────────────────────────────────────────────
+
+// publishHardwareDiscovery publishes HA discovery for hardware information.
+func (c *Client) publishHardwareDiscovery() {
+	topic := c.buildTopic("hardware")
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "bios_version", name: "Hardware: BIOS Version",
+		icon:           "mdi:chip",
+		template:       "{{ value_json.bios.version | default('') }}",
+		entityCategory: "diagnostic",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "bios_date", name: "Hardware: BIOS Release Date",
+		icon:           "mdi:calendar",
+		template:       "{{ value_json.bios.release_date | default('') }}",
+		entityCategory: "diagnostic",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "board_manufacturer", name: "Hardware: Board Manufacturer",
+		icon:           "mdi:factory",
+		template:       "{{ value_json.baseboard.manufacturer | default('') }}",
+		entityCategory: "diagnostic",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "board_model", name: "Hardware: Board Model",
+		icon:           "mdi:circuit-board",
+		template:       "{{ value_json.baseboard.product_name | default('') }}",
+		entityCategory: "diagnostic",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "cpu_max_speed", name: "Hardware: CPU Max Speed", unit: "MHz",
+		icon:           "mdi:cpu-64-bit",
+		template:       "{{ value_json.cpu.max_speed_mhz | default(0) }}",
+		entityCategory: "diagnostic",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "memory_slots_total", name: "Hardware: Memory Slots",
+		icon:           "mdi:memory",
+		template:       "{{ value_json.memory_array.number_of_devices | default(0) }}",
+		entityCategory: "diagnostic",
+	})
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Registration / License
+// ──────────────────────────────────────────────────────────────────────────────
+
+// publishRegistrationDiscovery publishes HA discovery for Unraid license/registration info.
+func (c *Client) publishRegistrationDiscovery() {
+	topic := c.buildTopic("registration")
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "registration_state", name: "Registration: State",
+		icon:     "mdi:license",
+		template: "{{ value_json.state }}",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "registration_type", name: "Registration: Type",
+		icon:           "mdi:tag",
+		template:       "{{ value_json.type }}",
+		entityCategory: "diagnostic",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "binary_sensor", stateTopic: topic,
+		id: "registration_valid", name: "Registration: Valid",
+		icon:        "mdi:check-decagram",
+		template:    "{{ 'ON' if value_json.state == 'valid' else 'OFF' }}",
+		deviceClass: "safety",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "registration_expiry", name: "Registration: Expiry",
+		icon:        "mdi:calendar-clock",
+		template:    "{{ value_json.expiration }}",
+		deviceClass: "timestamp",
+	})
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Unassigned Devices
+// ──────────────────────────────────────────────────────────────────────────────
+
+// publishUnassignedDiscovery publishes per-device HA discovery for unassigned devices.
+func (c *Client) publishUnassignedDiscovery(list *dto.UnassignedDeviceList) {
+	if !c.config.HomeAssistantMode {
+		return
+	}
+	if list == nil {
+		return
+	}
+	var currentIDs []string
+	for _, dev := range list.Devices {
+		if dev.Device == "" {
+			continue
+		}
+		devID := sanitizeID(dev.Device)
+		devTopic := c.buildTopic(fmt.Sprintf("unassigned/%s", devID))
+		if err := c.publishJSON(devTopic, dev); err != nil {
+			logger.Debug("MQTT: Failed to publish unassigned device %s: %v", devID, err)
+			continue
+		}
+		displayName := dev.Model
+		if displayName == "" {
+			displayName = dev.Device
+		}
+		ids := c.publishUnassignedEntities(devTopic, fmt.Sprintf("unassigned_%s", devID), displayName, dev)
+		currentIDs = append(currentIDs, ids...)
+	}
+	removed := c.tracker.update("unassigned", currentIDs)
+	for _, id := range removed {
+		c.removeHAEntities(id)
+	}
+}
+
+// publishUnassignedEntities publishes HA entity discovery for a single unassigned device.
+func (c *Client) publishUnassignedEntities(topic, prefix, displayName string, dev dto.UnassignedDevice) []string {
+	ids := []string{prefix + "_connected", prefix + "_temp", prefix + "_spin_state"}
+	c.publishHAEntity(haEntityOpts{
+		entityType: "binary_sensor", stateTopic: topic,
+		id: prefix + "_connected", name: fmt.Sprintf("Unassigned: %s Connected", displayName),
+		icon:        "mdi:harddisk",
+		template:    "{{ 'ON' if value_json.status != 'error' else 'OFF' }}",
+		deviceClass: "connectivity",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: prefix + "_temp", name: fmt.Sprintf("Unassigned: %s Temperature", displayName), unit: "°C",
+		icon:        "mdi:thermometer",
+		template:    "{{ value_json.temperature_celsius | default(0) }}",
+		deviceClass: "temperature", stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: prefix + "_spin_state", name: fmt.Sprintf("Unassigned: %s Spin State", displayName),
+		icon:     "mdi:rotate-3d-variant",
+		template: "{{ value_json.spin_state | default('unknown') }}",
+	})
+	for i, part := range dev.Partitions {
+		partPrefix := fmt.Sprintf("%s_part%d", prefix, i+1)
+		partLabel := part.Label
+		if partLabel == "" {
+			partLabel = fmt.Sprintf("Part %d", part.PartitionNumber)
+		}
+		ids = append(ids, partPrefix+"_usage", partPrefix+"_used", partPrefix+"_free")
+		c.publishHAEntity(haEntityOpts{
+			entityType: "sensor", stateTopic: topic,
+			id:   partPrefix + "_usage",
+			name: fmt.Sprintf("Unassigned: %s %s Usage", displayName, partLabel), unit: "%",
+			icon:       "mdi:harddisk",
+			template:   fmt.Sprintf("{{ value_json.partitions[%d].usage_percent | default(0) | round(1) }}", i),
+			stateClass: "measurement",
+		})
+		c.publishHAEntity(haEntityOpts{
+			entityType: "sensor", stateTopic: topic,
+			id:   partPrefix + "_used",
+			name: fmt.Sprintf("Unassigned: %s %s Used", displayName, partLabel), unit: "B",
+			icon:        "mdi:harddisk",
+			template:    fmt.Sprintf("{{ value_json.partitions[%d].used_bytes | default(0) }}", i),
+			deviceClass: "data_size", stateClass: "measurement",
+		})
+		c.publishHAEntity(haEntityOpts{
+			entityType: "sensor", stateTopic: topic,
+			id:   partPrefix + "_free",
+			name: fmt.Sprintf("Unassigned: %s %s Free", displayName, partLabel), unit: "B",
+			icon:        "mdi:harddisk",
+			template:    fmt.Sprintf("{{ value_json.partitions[%d].free_bytes | default(0) }}", i),
+			deviceClass: "data_size", stateClass: "measurement",
+		})
+	}
+	return ids
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ZFS Datasets
+// ──────────────────────────────────────────────────────────────────────────────
+
+// publishZFSDatasetDiscovery publishes per-dataset HA discovery for ZFS datasets.
+func (c *Client) publishZFSDatasetDiscovery(datasets []dto.ZFSDataset) {
+	if !c.config.HomeAssistantMode {
+		return
+	}
+	var currentIDs []string
+	for _, ds := range datasets {
+		if ds.Name == "" {
+			continue
+		}
+		dsID := sanitizeID(ds.Name)
+		dsTopic := c.buildTopic(fmt.Sprintf("zfs/datasets/%s", dsID))
+		if err := c.publishJSON(dsTopic, ds); err != nil {
+			logger.Debug("MQTT: Failed to publish ZFS dataset %s: %v", dsID, err)
+			continue
+		}
+		ids := c.publishZFSDatasetEntities(dsTopic, fmt.Sprintf("zfs_ds_%s", dsID), ds.Name)
+		currentIDs = append(currentIDs, ids...)
+	}
+	removed := c.tracker.update("zfs_datasets", currentIDs)
+	for _, id := range removed {
+		c.removeHAEntities(id)
+	}
+}
+
+// publishZFSDatasetEntities publishes HA entity discovery for a single ZFS dataset.
+func (c *Client) publishZFSDatasetEntities(topic, prefix, displayName string) []string {
+	ids := []string{prefix + "_used", prefix + "_available", prefix + "_compress_ratio", prefix + "_readonly"}
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: prefix + "_used", name: fmt.Sprintf("ZFS Dataset: %s Used", displayName), unit: "B",
+		icon:        "mdi:database",
+		template:    "{{ value_json.used_bytes }}",
+		deviceClass: "data_size", stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: prefix + "_available", name: fmt.Sprintf("ZFS Dataset: %s Available", displayName), unit: "B",
+		icon:        "mdi:database",
+		template:    "{{ value_json.available_bytes }}",
+		deviceClass: "data_size", stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: prefix + "_compress_ratio", name: fmt.Sprintf("ZFS Dataset: %s Compression Ratio", displayName),
+		icon:       "mdi:zip-box",
+		template:   "{{ value_json.compress_ratio | round(2) }}",
+		stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "binary_sensor", stateTopic: topic,
+		id: prefix + "_readonly", name: fmt.Sprintf("ZFS Dataset: %s Read-Only", displayName),
+		icon:     "mdi:lock",
+		template: "{{ 'ON' if value_json.readonly else 'OFF' }}",
+	})
+	return ids
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ZFS Snapshots
+// ──────────────────────────────────────────────────────────────────────────────
+
+// publishZFSSnapshotDiscovery publishes aggregate HA discovery for ZFS snapshots.
+func (c *Client) publishZFSSnapshotDiscovery() {
+	topic := c.buildTopic("zfs/snapshots")
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "zfs_snapshot_count", name: "ZFS: Snapshot Count",
+		icon:       "mdi:camera",
+		template:   "{{ value_json | length }}",
+		stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "zfs_snapshot_total_size", name: "ZFS: Snapshot Total Size", unit: "B",
+		icon:        "mdi:camera",
+		template:    "{{ value_json | sum(attribute='used_bytes') | default(0) }}",
+		deviceClass: "data_size", stateClass: "measurement",
+	})
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ZFS ARC Stats
+// ──────────────────────────────────────────────────────────────────────────────
+
+// publishZFSARCDiscovery publishes HA discovery for ZFS ARC cache statistics.
+func (c *Client) publishZFSARCDiscovery() {
+	topic := c.buildTopic("zfs/arc")
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "arc_size", name: "ZFS ARC: Size", unit: "B",
+		icon:        "mdi:memory",
+		template:    "{{ value_json.size_bytes }}",
+		deviceClass: "data_size", stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "arc_target_size", name: "ZFS ARC: Target Size", unit: "B",
+		icon:           "mdi:memory",
+		template:       "{{ value_json.target_size_bytes }}",
+		deviceClass:    "data_size", stateClass: "measurement",
+		entityCategory: "diagnostic",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "arc_hit_ratio", name: "ZFS ARC: Hit Ratio", unit: "%",
+		icon:       "mdi:chart-line",
+		template:   "{{ value_json.hit_ratio_percent | round(1) }}",
+		stateClass: "measurement",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "arc_l2_size", name: "ZFS L2ARC: Size", unit: "B",
+		icon:           "mdi:memory",
+		template:       "{{ value_json.l2_size_bytes | default(0) }}",
+		deviceClass:    "data_size", stateClass: "measurement",
+		entityCategory: "diagnostic",
+	})
+	c.publishHAEntity(haEntityOpts{
+		entityType: "sensor", stateTopic: topic,
+		id: "arc_l2_hit_ratio", name: "ZFS L2ARC: Hit Ratio", unit: "%",
+		icon:           "mdi:chart-line",
+		template:       "{{ ((value_json.l2_hits | default(0)) / ((value_json.l2_hits | default(0)) + (value_json.l2_misses | default(0))) * 100) | round(1) if ((value_json.l2_hits | default(0)) + (value_json.l2_misses | default(0))) > 0 else 0 }}",
+		stateClass:     "measurement",
+		entityCategory: "diagnostic",
+	})
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/daemon/services/orchestrator.go
+++ b/daemon/services/orchestrator.go
@@ -313,6 +313,13 @@ func (o *Orchestrator) subscribeMQTTEvents(ctx context.Context, _ *api.Server) {
 		mqttBind(constants.TopicNetworkListUpdate, o.mqttClient.PublishNetworkInfo),
 		mqttBind(constants.TopicNotificationsUpdate, o.mqttClient.PublishNotifications),
 		mqttBind(constants.TopicZFSPoolsUpdate, o.mqttClient.PublishZFSPools),
+		mqttBind(constants.TopicNUTStatusUpdate, o.mqttClient.PublishNUTStatus),
+		mqttBind(constants.TopicHardwareUpdate, o.mqttClient.PublishHardwareInfo),
+		mqttBind(constants.TopicRegistrationUpdate, o.mqttClient.PublishRegistration),
+		mqttBind(constants.TopicUnassignedDevicesUpdate, o.mqttClient.PublishUnassignedDevices),
+		mqttBind(constants.TopicZFSDatasetsUpdate, o.mqttClient.PublishZFSDatasets),
+		mqttBind(constants.TopicZFSSnapshotsUpdate, o.mqttClient.PublishZFSSnapshots),
+		mqttBind(constants.TopicZFSARCStatsUpdate, o.mqttClient.PublishZFSARCStats),
 	}
 
 	topics := make([]string, len(bindings))


### PR DESCRIPTION
## Summary

7 collector event topics were being broadcast via WebSocket but silently dropped by the MQTT subscriber. This wires them all up and adds full Home Assistant MQTT discovery for each.

**Root cause:** `orchestrator.go:subscribeMQTTEvents()` is a manually-maintained list. When the NUT, hardware, registration, unassigned devices, and ZFS dataset/snapshot/ARC collectors were added, they got entries in `cacheBindings()` (which auto-enables WebSocket broadcast) but no corresponding `mqttBind()` entries.

**New topics published:**

| Topic | Data |
|-------|------|
| `{prefix}/nut/status` | NUT UPS status (battery, load, voltage, runtime, model) |
| `{prefix}/hardware` | BIOS, baseboard, CPU, memory slot info |
| `{prefix}/registration` | License state, type, expiry |
| `{prefix}/unassigned/devices` | Unassigned disk list + per-device subtopics |
| `{prefix}/zfs/datasets` | ZFS dataset list + per-dataset subtopics |
| `{prefix}/zfs/snapshots` | ZFS snapshot list (aggregate) |
| `{prefix}/zfs/arc` | ZFS ARC/L2ARC cache stats |

**HA discovery entities added:**
- **NUT:** connected (binary), status, battery charge/runtime, load, real power, input/output voltage, model
- **Hardware:** BIOS version/date, board manufacturer/model, CPU max speed, memory slots (all diagnostic)
- **Registration:** state, type, valid (binary), expiry timestamp
- **Unassigned devices:** per-device connected (binary), temperature, spin state; per-partition usage/used/free
- **ZFS datasets:** per-dataset used, available, compression ratio, read-only (binary)
- **ZFS snapshots:** aggregate count + total size
- **ZFS ARC:** size, target size, hit ratio, L2ARC size, L2ARC hit ratio (derived from `l2_hits`/`l2_misses`)

Per-item discovery (unassigned devices, ZFS datasets) uses the existing `discoveryTracker` pattern to clean up stale HA entities when items disappear.

`MQTTTopics` DTO extended with 7 new fields; `/api/v1/mqtt/topics` endpoint reflects them.

## Test plan

- [ ] `go test -race ./daemon/services/mqtt/... ./daemon/dto/...` — all pass
- [ ] `go build ./...` — clean build
- [ ] With a live MQTT broker + HA: restart the agent, confirm new topics appear in MQTT Explorer under the configured prefix
- [ ] Confirm HA auto-discovers the new entities under the existing Unraid device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended MQTT publishing to include UPS status data, system hardware information, registration and licensing details, unassigned storage devices, ZFS datasets, snapshots, and ARC cache statistics.
  * Implemented comprehensive Home Assistant MQTT discovery support for all newly available data types, enabling automatic entity discovery in Home Assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->