### PR TITLE
fix(collectors): use zpool capacity for ZFS disk usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **ZFS cache/pool disk usage in `/api/v1/disks`** — disk collection now resolves ZFS-backed
+  cache and pool members to their owning zpool and uses `zpool list` capacity data instead of
+  `statfs()` on `/mnt/<disk>`, fixing near-zero usage on root datasets and `null` usage for
+  mirrored members like `cache2`
+
 ## [2026.04.01] - 2026-04-10
 
 ### Fixed

--- a/daemon/services/collectors/disk.go
+++ b/daemon/services/collectors/disk.go
@@ -26,6 +26,13 @@ type DiskCollector struct {
 	prevCollectTime time.Time
 }
 
+type zfsPoolUsage struct {
+	Size         uint64
+	Used         uint64
+	Free         uint64
+	UsagePercent float64
+}
+
 // NewDiskCollector creates a new disk information collector with the given context.
 func NewDiskCollector(ctx *domain.Context) *DiskCollector {
 	return &DiskCollector{
@@ -271,6 +278,8 @@ func (c *DiskCollector) parseDiskKeyValue(disk *dto.DiskInfo, line string) {
 
 // enrichDisks enhances each disk with additional statistics
 func (c *DiskCollector) enrichDisks(disks []dto.DiskInfo) {
+	zfsPoolUsages := c.getZFSPoolUsages()
+
 	for i := range disks {
 		// Get model and serial number
 		c.enrichWithModelAndSerial(&disks[i])
@@ -288,6 +297,10 @@ func (c *DiskCollector) enrichDisks(disks []dto.DiskInfo) {
 
 		// Get disk role
 		c.enrichWithRole(&disks[i])
+
+		// For ZFS cache/pool disks, override statfs values with pool-level usage
+		// so mirrored pools and child datasets report the same numbers as Unraid.
+		c.enrichWithZFSPoolUsage(&disks[i], zfsPoolUsages)
 
 		// Get spin state
 		if disks[i].Device != "" {
@@ -685,6 +698,126 @@ func (c *DiskCollector) enrichWithRole(disk *dto.DiskInfo) {
 	default:
 		disk.Role = "unknown"
 	}
+}
+
+func shouldUseZFSPoolUsage(disk *dto.DiskInfo) bool {
+	if strings.EqualFold(disk.FileSystem, "zfs") {
+		return true
+	}
+
+	return disk.Role == "cache" || disk.Role == "pool"
+}
+
+func resolveZFSPoolName(disk *dto.DiskInfo, poolUsages map[string]zfsPoolUsage) (string, bool) {
+	if len(poolUsages) == 0 {
+		return "", false
+	}
+
+	diskName := strings.TrimSpace(disk.Name)
+	if _, ok := poolUsages[diskName]; ok {
+		return diskName, true
+	}
+
+	trimmedName := strings.TrimRightFunc(diskName, func(r rune) bool {
+		return r >= '0' && r <= '9'
+	})
+	if trimmedName != "" && trimmedName != diskName {
+		if _, ok := poolUsages[trimmedName]; ok {
+			return trimmedName, true
+		}
+	}
+
+	if disk.MountPoint != "" && strings.HasPrefix(disk.MountPoint, "/mnt/") {
+		poolName := strings.TrimPrefix(disk.MountPoint, "/mnt/")
+		poolName = strings.SplitN(poolName, "/", 2)[0]
+		if _, ok := poolUsages[poolName]; ok {
+			return poolName, true
+		}
+	}
+
+	return "", false
+}
+
+func (c *DiskCollector) enrichWithZFSPoolUsage(disk *dto.DiskInfo, poolUsages map[string]zfsPoolUsage) bool {
+	if !shouldUseZFSPoolUsage(disk) {
+		return false
+	}
+
+	poolName, ok := resolveZFSPoolName(disk, poolUsages)
+	if !ok {
+		return false
+	}
+
+	usage := poolUsages[poolName]
+
+	disk.Size = usage.Size
+	disk.Used = usage.Used
+	disk.Free = usage.Free
+	disk.UsagePercent = usage.UsagePercent
+
+	return true
+}
+
+func (c *DiskCollector) getZFSPoolUsages() map[string]zfsPoolUsage {
+	output, err := lib.ExecCommandOutput(constants.ZpoolBin, "list", "-Hp", "-o",
+		"name,size,allocated,free,capacity")
+	if err != nil {
+		logger.Debug("Disk: Failed to load ZFS pool usage: %v", err)
+		return nil
+	}
+
+	usages := make(map[string]zfsPoolUsage)
+	for _, line := range strings.Split(output, "\n") {
+		name, usage, ok := parseZFSPoolUsageLine(line)
+		if ok {
+			usages[name] = usage
+		}
+	}
+
+	if len(usages) == 0 {
+		logger.Debug("Disk: No parseable ZFS pool usage found in zpool output")
+	}
+
+	return usages
+}
+
+func parseZFSPoolUsageLine(line string) (string, zfsPoolUsage, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return "", zfsPoolUsage{}, false
+	}
+
+	fields := strings.Fields(line)
+	if len(fields) < 5 {
+		return "", zfsPoolUsage{}, false
+	}
+
+	size, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return "", zfsPoolUsage{}, false
+	}
+
+	used, err := strconv.ParseUint(fields[2], 10, 64)
+	if err != nil {
+		return "", zfsPoolUsage{}, false
+	}
+
+	free, err := strconv.ParseUint(fields[3], 10, 64)
+	if err != nil {
+		return "", zfsPoolUsage{}, false
+	}
+
+	usagePercent, err := strconv.ParseFloat(strings.TrimSuffix(fields[4], "%"), 64)
+	if err != nil {
+		return "", zfsPoolUsage{}, false
+	}
+
+	return fields[0], zfsPoolUsage{
+		Size:         size,
+		Used:         used,
+		Free:         free,
+		UsagePercent: usagePercent,
+	}, true
 }
 
 // enrichWithSpinState checks the current spin state of the disk

--- a/daemon/services/collectors/disk_test.go
+++ b/daemon/services/collectors/disk_test.go
@@ -617,6 +617,206 @@ func TestEnrichWithModelAndSerialNoDevice(t *testing.T) {
 	}
 }
 
+func TestResolveZFSPoolName(t *testing.T) {
+	poolUsages := map[string]zfsPoolUsage{
+		"cache":    {},
+		"fastpool": {},
+		"cache2":   {},
+	}
+
+	tests := []struct {
+		name     string
+		disk     dto.DiskInfo
+		pools    map[string]zfsPoolUsage
+		wantPool string
+		wantOK   bool
+	}{
+		{
+			name:     "exact pool name match",
+			disk:     dto.DiskInfo{Name: "cache"},
+			pools:    poolUsages,
+			wantPool: "cache",
+			wantOK:   true,
+		},
+		{
+			name: "mirror member resolves by stripping suffix digits",
+			disk: dto.DiskInfo{Name: "cache2"},
+			pools: map[string]zfsPoolUsage{
+				"cache": {},
+			},
+			wantPool: "cache",
+			wantOK:   true,
+		},
+		{
+			name: "other pool member resolves by stripping suffix digits",
+			disk: dto.DiskInfo{Name: "fastpool2"},
+			pools: map[string]zfsPoolUsage{
+				"fastpool": {},
+			},
+			wantPool: "fastpool",
+			wantOK:   true,
+		},
+		{
+			name:     "non matching disk name does not resolve",
+			disk:     dto.DiskInfo{Name: "disk1"},
+			pools:    poolUsages,
+			wantPool: "",
+			wantOK:   false,
+		},
+		{
+			name: "exact pool name wins before stripping digits",
+			disk: dto.DiskInfo{Name: "cache2"},
+			pools: map[string]zfsPoolUsage{
+				"cache2": {},
+				"cache":  {},
+			},
+			wantPool: "cache2",
+			wantOK:   true,
+		},
+		{
+			name:  "mount point can resolve pool",
+			disk:  dto.DiskInfo{Name: "member1", MountPoint: "/mnt/cache/appdata"},
+			pools: poolUsages,
+			wantPool: "cache",
+			wantOK:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPool, gotOK := resolveZFSPoolName(&tt.disk, tt.pools)
+			if gotOK != tt.wantOK {
+				t.Fatalf("resolveZFSPoolName() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotPool != tt.wantPool {
+				t.Errorf("resolveZFSPoolName() pool = %q, want %q", gotPool, tt.wantPool)
+			}
+		})
+	}
+}
+
+func TestParseZFSPoolUsageLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		wantPool string
+		want    zfsPoolUsage
+		wantOK  bool
+	}{
+		{
+			name:   "plain capacity number",
+			output: "cache\t965845127168\t180000000000\t785845127168\t18",
+			wantPool: "cache",
+			want: zfsPoolUsage{
+				Size:         965845127168,
+				Used:         180000000000,
+				Free:         785845127168,
+				UsagePercent: 18,
+			},
+			wantOK: true,
+		},
+		{
+			name:   "capacity with percent suffix",
+			output: "cache\t965845127168\t180000000000\t785845127168\t18%",
+			wantPool: "cache",
+			want: zfsPoolUsage{
+				Size:         965845127168,
+				Used:         180000000000,
+				Free:         785845127168,
+				UsagePercent: 18,
+			},
+			wantOK: true,
+		},
+		{
+			name:   "invalid output is rejected",
+			output: "cache\tbad\t180000000000\t785845127168\t18",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPool, got, gotOK := parseZFSPoolUsageLine(tt.output)
+			if gotOK != tt.wantOK {
+				t.Fatalf("parseZFSPoolUsageLine() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+
+			if gotPool != tt.wantPool {
+				t.Errorf("parseZFSPoolUsageLine() pool = %q, want %q", gotPool, tt.wantPool)
+			}
+			if got != tt.want {
+				t.Errorf("parseZFSPoolUsageLine() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnrichWithZFSPoolUsage(t *testing.T) {
+	collector := &DiskCollector{}
+	poolUsages := map[string]zfsPoolUsage{
+		"cache": {
+			Size:         965845127168,
+			Used:         180000000000,
+			Free:         785845127168,
+			UsagePercent: 18,
+		},
+	}
+
+	t.Run("zfs cache disk gets pool usage", func(t *testing.T) {
+		disk := &dto.DiskInfo{
+			Name:          "cache2",
+			Role:          "cache",
+			FileSystem:    "zfs",
+			Size:          1,
+			Used:          2,
+			Free:          3,
+			UsagePercent:  4,
+		}
+
+		applied := collector.enrichWithZFSPoolUsage(disk, poolUsages)
+		if !applied {
+			t.Fatal("enrichWithZFSPoolUsage() = false, want true")
+		}
+
+		if disk.Size != poolUsages["cache"].Size {
+			t.Errorf("Size = %d, want %d", disk.Size, poolUsages["cache"].Size)
+		}
+		if disk.Used != poolUsages["cache"].Used {
+			t.Errorf("Used = %d, want %d", disk.Used, poolUsages["cache"].Used)
+		}
+		if disk.Free != poolUsages["cache"].Free {
+			t.Errorf("Free = %d, want %d", disk.Free, poolUsages["cache"].Free)
+		}
+		if disk.UsagePercent != poolUsages["cache"].UsagePercent {
+			t.Errorf("UsagePercent = %f, want %f", disk.UsagePercent, poolUsages["cache"].UsagePercent)
+		}
+	})
+
+	t.Run("non zfs non pool disk is unchanged", func(t *testing.T) {
+		disk := &dto.DiskInfo{
+			Name:         "disk1",
+			Role:         "data",
+			FileSystem:   "xfs",
+			Size:         10,
+			Used:         20,
+			Free:         30,
+			UsagePercent: 40,
+		}
+
+		applied := collector.enrichWithZFSPoolUsage(disk, poolUsages)
+		if applied {
+			t.Fatal("enrichWithZFSPoolUsage() = true, want false")
+		}
+
+		if disk.Size != 10 || disk.Used != 20 || disk.Free != 30 || disk.UsagePercent != 40 {
+			t.Errorf("disk was modified unexpectedly: %+v", disk)
+		}
+	})
+}
+
 // TestEnrichWithModelAndSerialEmptyID tests enrichment when ID is empty
 func TestEnrichWithModelAndSerialEmptyID(t *testing.T) {
 	hub := domain.NewEventBus(10)


### PR DESCRIPTION
## Description

Fix incorrect disk usage reporting for ZFS-backed cache and pool disks in `/api/v1/disks`.

Previously, the disk collector relied on `statfs()` for disk usage. This works for normal array disks, but it reports incorrect usage for ZFS pools because `/mnt/<pool>` only reflects the root dataset, while most real usage may live in child datasets. It also caused mirrored members such as `cache2` to report missing usage because they do not have their own mountpoint.

This change resolves ZFS-backed cache/pool disks to their owning zpool and uses `zpool list` capacity data instead of root-dataset `statfs()` values. As a result, `/api/v1/disks` now reports pool-level `size_bytes`, `used_bytes`, `free_bytes`, and `usage_percent` that match actual ZFS pool usage.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Hardware compatibility fix
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [x] Test additions/improvements

## Related Issues

Related to ZFS cache pool usage being reported incorrectly in `/api/v1/disks`.

## Hardware Configuration (if applicable)

- **Other:** Mirrored ZFS cache pool (`cache` / `cache2`)
- **Unraid Version:** 7.3.0

## Changes Made

- Added ZFS pool usage enrichment in the disk collector using `zpool list -Hp -o name,size,allocated,free,capacity`
- Resolved ZFS-backed disks to their owning pool using exact pool name matches, numeric suffix stripping (for example `cache2 -> cache`), and `/mnt/<pool>` mountpoint fallback
- Added unit tests for pool resolution, `zpool` output parsing, and ZFS pool usage enrichment
- Updated `CHANGELOG.md` with the fix

## Testing Performed

- [ ] Unit tests pass (`make test`)
- [x] Added new tests for new functionality
- [x] Tested on actual Unraid system
- [x] Verified affected API endpoints work correctly
- [ ] Tested WebSocket events (if applicable)
- [ ] Tested with debug logging enabled
- [ ] Regression testing (ensured existing functionality still works)

### Test Results

Validated on an actual Unraid server with a mirrored ZFS cache pool.

Before this change:
- `/api/v1/disks` reported near-zero usage for `cache`
- mirrored member `cache2` reported missing usage because it has no separate mountpoint
- Home Assistant showed incorrect values such as `0.0%`

After this change:
- `/api/v1/disks` reports pool-level usage for both `cache` and `cache2`
- values now match `zpool list`
- Home Assistant now shows the expected usage for both entities

## **API Endpoints Tested:**

- `GET /api/v1/disks`

- **Test Output/Results:**

```bash
curl -s http://127.0.0.1:8043/api/v1/disks | jq '.[] | select(.name=="cache" or .name=="cache2") | {name,role,filesystem,mount_point,size_bytes,used_bytes,free_bytes,usage_percent}'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed disk usage reporting for ZFS-backed cache and pool members
  * Improved accuracy of capacity metrics for mirrored ZFS pool members and root datasets that previously displayed null or near-zero values

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ruaan-deysel/unraid-management-agent/pull/112)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->