### PR TITLE
chore(security): upgrade Go toolchain 1.26.3 → 1.26.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Extract version from tag
         id: version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Upgraded Go toolchain 1.26.3 → 1.26.4** — picks up the standard-library
+  security fixes in Go 1.26.4 (released 2026-06-02): CVE-2026-27145
+  (`net/textproto`, reached via `net/http` response-header parsing —
+  relevant to the daemon's outbound HTTP), CVE-2026-39822 (`crypto/x509`),
+  and CVE-2026-42504 (`mime`). Bumped the `go` directive in `go.mod` and the
+  `setup-go` version in the release workflow.
+
 ### Added
 
 - **Remote share mount/unmount control** (issue #115; resolves the mount/unmount toggle

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ruaan-deysel/unraid-management-agent
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/alecthomas/kong v1.15.0


### PR DESCRIPTION
## Summary

Upgrades the Go toolchain from **1.26.3 → 1.26.4** (released 2026-06-02) to pick up standard-library security fixes.

### CVEs addressed
- **CVE-2026-27145** (`net/textproto`) — unescaped input in errors, reachable via `net/http` response-header parsing. The daemon makes outbound HTTP (health-check probes, plugin/OS update checks, shoutrrr notifications), so it's exposed.
- **CVE-2026-39822** (`crypto/x509`).
- **CVE-2026-42504** (`mime`) — quadratic complexity in `WordDecoder.DecodeHeader`.

### Changes
- `go.mod`: `go 1.26.3` → `go 1.26.4`
- `.github/workflows/release.yml`: `setup-go` `1.26.3` → `1.26.4`
- CHANGELOG Security entry

### Verification
- Builds with `go1.26.4` (fetched automatically via `GOTOOLCHAIN=auto`).
- Full `daemon/...` test suite passes.
- `govulncheck ./...` → **No vulnerabilities found.**

Patch release only — no language changes, minimal risk.