### PR TITLE
docs(changelog): set 2026.06.01 release date to 2026-06-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2026.06.01] - 2026-06-05
+## [2026.06.01] - 2026-06-01
 
 ### Added
 


### PR DESCRIPTION
Corrects the `[2026.06.01]` heading date to **2026-06-01** as intended (it had landed as 2026-06-05). No content changes.