### PR TITLE
fix(server): native HTTPS/TLS for REST & MCP endpoint (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Native HTTPS/TLS for the HTTP & MCP server** (#131) — the agent can now serve
+  the REST API and the `/mcp` endpoint over HTTPS when pointed at a PEM
+  certificate/key pair via `--tls-cert-file`/`--tls-key-file`, the
+  `TLS_CERT_FILE`/`TLS_KEY_FILE` environment variables, or `tls_cert_file`/
+  `tls_key_file` in `config.yml`. TLS is enabled only when both files are set;
+  an invalid, half-configured, or unloadable pair logs a warning and falls back
+  to plain HTTP so a stale path can never make the agent unreachable. mDNS
+  discovery now advertises a `scheme=https`/`scheme=http` TXT record and the
+  `/network/access-urls` endpoint returns `https://…` URLs when TLS is active.
+
+### Fixed
+
+- **Claude Desktop "HTTP is not supported" when adding the agent** (#131) — the
+  Claude integration guide now documents that Custom Connectors are reached from
+  Anthropic's cloud (so a LAN URL is unreachable even over HTTPS) and gives the
+  two paths that actually work: the `mcp-remote --allow-http` stdio bridge for
+  LAN-only use (no TLS required), and native HTTPS with a publicly-trusted
+  certificate behind a port-forward/tunnel for Custom Connectors.
+
 ## [2026.06.09] - 2026-06-16
 
 ### Fixed

--- a/daemon/domain/config.go
+++ b/daemon/domain/config.go
@@ -3,6 +3,7 @@ package domain
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ruaan-deysel/unraid-management-agent/daemon/dto"
 )
@@ -51,9 +52,11 @@ type Config struct {
 }
 
 // TLSEnabled reports whether HTTPS should be served. TLS is considered enabled
-// only when both a certificate and key file are configured.
+// only when both a certificate and key file are configured. Whitespace-only
+// values are treated as unset so they don't mislead the HTTPS branch before
+// validation runs.
 func (c Config) TLSEnabled() bool {
-	return c.TLSCertFile != "" && c.TLSKeyFile != ""
+	return strings.TrimSpace(c.TLSCertFile) != "" && strings.TrimSpace(c.TLSKeyFile) != ""
 }
 
 // DiscoveryConfig holds zeroconf (mDNS/DNS-SD) auto-discovery settings.

--- a/daemon/domain/config.go
+++ b/daemon/domain/config.go
@@ -43,6 +43,17 @@ type Config struct {
 	// ReadOnly blocks all state-changing MCP tools so AI agents can only
 	// consume data. The REST API is unaffected.
 	ReadOnly bool `json:"read_only,omitempty"`
+	// TLSCertFile and TLSKeyFile point at a PEM certificate/key pair. When both
+	// are set the HTTP server (including the /mcp endpoint) is served over HTTPS;
+	// when either is empty the server stays on plain HTTP.
+	TLSCertFile string `json:"tls_cert_file,omitempty"`
+	TLSKeyFile  string `json:"tls_key_file,omitempty"`
+}
+
+// TLSEnabled reports whether HTTPS should be served. TLS is considered enabled
+// only when both a certificate and key file are configured.
+func (c Config) TLSEnabled() bool {
+	return c.TLSCertFile != "" && c.TLSKeyFile != ""
 }
 
 // DiscoveryConfig holds zeroconf (mDNS/DNS-SD) auto-discovery settings.

--- a/daemon/domain/config_test.go
+++ b/daemon/domain/config_test.go
@@ -168,6 +168,8 @@ func TestConfigTLSEnabled(t *testing.T) {
 		{name: "neither set disables TLS", certFile: "", keyFile: "", want: false},
 		{name: "only cert set disables TLS", certFile: "/boot/cert.pem", keyFile: "", want: false},
 		{name: "only key set disables TLS", certFile: "", keyFile: "/boot/key.pem", want: false},
+		{name: "whitespace-only paths disable TLS", certFile: "  ", keyFile: "\t\n", want: false},
+		{name: "whitespace cert with real key disables TLS", certFile: "   ", keyFile: "/boot/key.pem", want: false},
 	}
 
 	for _, tt := range tests {

--- a/daemon/domain/config_test.go
+++ b/daemon/domain/config_test.go
@@ -157,6 +157,29 @@ func TestToDTOConfig_ZeroPort(t *testing.T) {
 	}
 }
 
+func TestConfigTLSEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		certFile string
+		keyFile  string
+		want     bool
+	}{
+		{name: "both set enables TLS", certFile: "/boot/cert.pem", keyFile: "/boot/key.pem", want: true},
+		{name: "neither set disables TLS", certFile: "", keyFile: "", want: false},
+		{name: "only cert set disables TLS", certFile: "/boot/cert.pem", keyFile: "", want: false},
+		{name: "only key set disables TLS", certFile: "", keyFile: "/boot/key.pem", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Config{TLSCertFile: tt.certFile, TLSKeyFile: tt.keyFile}
+			if got := c.TLSEnabled(); got != tt.want {
+				t.Errorf("TLSEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestContextFields(t *testing.T) {
 	ctx := Context{
 		Config: Config{

--- a/daemon/domain/fileconfig.go
+++ b/daemon/domain/fileconfig.go
@@ -31,6 +31,10 @@ type FileConfig struct {
 	// CORS
 	CORSOrigin *string `yaml:"cors_origin,omitempty"`
 
+	// TLS: serve HTTPS when both a certificate and key file are provided.
+	TLSCertFile *string `yaml:"tls_cert_file,omitempty"`
+	TLSKeyFile  *string `yaml:"tls_key_file,omitempty"`
+
 	// MQTT configuration
 	MQTT *FileConfigMQTT `yaml:"mqtt,omitempty"`
 

--- a/daemon/lib/validation.go
+++ b/daemon/lib/validation.go
@@ -1,14 +1,20 @@
 package lib
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
+	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/ruaan-deysel/unraid-management-agent/daemon/dto"
 )
+
+// maxTLSPathLen caps TLS file paths defensively. Filesystem paths are well under
+// this on Unraid; the cap exists only to reject absurd input early.
+const maxTLSPathLen = 4096
 
 var (
 	// Docker container IDs are either 12 or 64 hexadecimal characters
@@ -457,6 +463,52 @@ func ValidateBindAddress(addr string) error {
 		}
 	}
 	return fmt.Errorf("bind address %q is not assigned to any local interface", addr)
+}
+
+// ValidateTLSConfig validates the optional HTTPS certificate/key configuration.
+// TLS is treated as enabled only when both paths are supplied; supplying just
+// one is a misconfiguration. Each path is checked defensively and the pair must
+// form a loadable X.509 key pair, so a bad cert is caught before the listener
+// starts. An empty pair (TLS disabled) is valid and returns nil.
+func ValidateTLSConfig(certFile, keyFile string) error {
+	if certFile == "" && keyFile == "" {
+		return nil // TLS disabled — plain HTTP
+	}
+	if certFile == "" || keyFile == "" {
+		return errors.New("TLS requires both a certificate and a key file (set tls_cert_file and tls_key_file together)")
+	}
+	if err := validateTLSPath(certFile, "TLS certificate file"); err != nil {
+		return err
+	}
+	if err := validateTLSPath(keyFile, "TLS key file"); err != nil {
+		return err
+	}
+	if _, err := tls.LoadX509KeyPair(certFile, keyFile); err != nil {
+		return fmt.Errorf("loading TLS key pair: %w", err)
+	}
+	return nil
+}
+
+// validateTLSPath applies the standard path guard sequence used across the
+// validators: non-empty, length cap, null-byte (CWE-158), path traversal
+// (CWE-22), and an absolute-path requirement.
+func validateTLSPath(path, field string) error {
+	if path == "" {
+		return fmt.Errorf("%s cannot be empty", field)
+	}
+	if len(path) > maxTLSPathLen {
+		return fmt.Errorf("%s exceeds maximum length of %d characters", field, maxTLSPathLen)
+	}
+	if strings.ContainsRune(path, 0) {
+		return fmt.Errorf("%s cannot contain null bytes", field) // CWE-158
+	}
+	if strings.Contains(path, "..") {
+		return fmt.Errorf("%s cannot contain path traversal sequences", field) // CWE-22
+	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("%s must be an absolute path", field)
+	}
+	return nil
 }
 
 // ValidateFanTempSource validates a fan curve temperature source.

--- a/daemon/lib/validation.go
+++ b/daemon/lib/validation.go
@@ -502,8 +502,12 @@ func validateTLSPath(path, field string) error {
 	if strings.ContainsRune(path, 0) {
 		return fmt.Errorf("%s cannot contain null bytes", field) // CWE-158
 	}
-	if strings.Contains(path, "..") {
-		return fmt.Errorf("%s cannot contain path traversal sequences", field) // CWE-22
+	// Reject a literal ".." path segment (CWE-22) without rejecting legitimate
+	// names that merely contain dots, e.g. /boot/certs/archive..old/cert.pem.
+	for _, seg := range strings.Split(filepath.ToSlash(path), "/") {
+		if seg == ".." {
+			return fmt.Errorf("%s cannot contain path traversal sequences", field) // CWE-22
+		}
 	}
 	if !filepath.IsAbs(path) {
 		return fmt.Errorf("%s must be an absolute path", field)

--- a/daemon/lib/validation_tls_test.go
+++ b/daemon/lib/validation_tls_test.go
@@ -60,6 +60,15 @@ func TestValidateTLSConfig(t *testing.T) {
 	dir := t.TempDir()
 	certPath, keyPath := writeTestKeyPair(t, dir)
 
+	// A loadable pair living under a directory whose name merely contains dots
+	// (not a ".." segment). This must be accepted — it guards against an
+	// over-broad traversal check rejecting legitimate paths.
+	dottedDir := filepath.Join(dir, "archive..old")
+	if err := os.MkdirAll(dottedDir, 0o700); err != nil {
+		t.Fatalf("mkdir dotted dir: %v", err)
+	}
+	dottedCert, dottedKey := writeTestKeyPair(t, dottedDir)
+
 	tests := []struct {
 		name     string
 		certFile string
@@ -68,11 +77,18 @@ func TestValidateTLSConfig(t *testing.T) {
 	}{
 		{name: "both empty is TLS disabled", certFile: "", keyFile: "", wantErr: false},
 		{name: "valid loadable key pair", certFile: certPath, keyFile: keyPath, wantErr: false},
+		{name: "dotted but legitimate component name", certFile: dottedCert, keyFile: dottedKey, wantErr: false},
 		{name: "only cert provided", certFile: certPath, keyFile: "", wantErr: true},
 		{name: "only key provided", certFile: "", keyFile: keyPath, wantErr: true},
 		{name: "relative cert path", certFile: "certs/cert.pem", keyFile: keyPath, wantErr: true},
-		{name: "path traversal in key", certFile: certPath, keyFile: "/boot/../etc/key.pem", wantErr: true},
+		{name: "path traversal in key (unix)", certFile: certPath, keyFile: "/boot/../etc/key.pem", wantErr: true},
+		{name: "path traversal in key (windows sep)", certFile: certPath, keyFile: `/boot/..\etc/key.pem`, wantErr: true},
+		{name: "relative traversal cert", certFile: "../../etc/passwd", keyFile: keyPath, wantErr: true},
 		{name: "null byte in cert", certFile: "/boot/cert\x00.pem", keyFile: keyPath, wantErr: true},
+		{name: "arbitrary absolute file is not a cert", certFile: "/etc/passwd", keyFile: keyPath, wantErr: true},
+		{name: "command-injection style path", certFile: "/boot/cert.pem; rm -rf /", keyFile: keyPath, wantErr: true},
+		{name: "subshell style path", certFile: "/boot/$(whoami)/cert.pem", keyFile: keyPath, wantErr: true},
+		{name: "backtick style path", certFile: "/boot/`id`/cert.pem", keyFile: keyPath, wantErr: true},
 		{name: "missing files but valid paths", certFile: "/nonexistent/cert.pem", keyFile: "/nonexistent/key.pem", wantErr: true},
 		{name: "key file is not a key pair", certFile: certPath, keyFile: certPath, wantErr: true},
 		{name: "over-long cert path", certFile: "/" + strings.Repeat("a", maxTLSPathLen), keyFile: keyPath, wantErr: true},

--- a/daemon/lib/validation_tls_test.go
+++ b/daemon/lib/validation_tls_test.go
@@ -1,0 +1,89 @@
+package lib
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTestKeyPair generates a throwaway self-signed certificate/key pair and
+// writes them to the given directory, returning the absolute file paths. It is
+// only used to exercise the loadable-key-pair branch of ValidateTLSConfig.
+func writeTestKeyPair(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+
+	certPath = filepath.Join(dir, "cert.pem")
+	certOut := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(certPath, certOut, 0o600); err != nil {
+		t.Fatalf("writing cert: %v", err)
+	}
+
+	keyBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshaling key: %v", err)
+	}
+	keyPath = filepath.Join(dir, "key.pem")
+	keyOut := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	if err := os.WriteFile(keyPath, keyOut, 0o600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+
+	return certPath, keyPath
+}
+
+func TestValidateTLSConfig(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeTestKeyPair(t, dir)
+
+	tests := []struct {
+		name     string
+		certFile string
+		keyFile  string
+		wantErr  bool
+	}{
+		{name: "both empty is TLS disabled", certFile: "", keyFile: "", wantErr: false},
+		{name: "valid loadable key pair", certFile: certPath, keyFile: keyPath, wantErr: false},
+		{name: "only cert provided", certFile: certPath, keyFile: "", wantErr: true},
+		{name: "only key provided", certFile: "", keyFile: keyPath, wantErr: true},
+		{name: "relative cert path", certFile: "certs/cert.pem", keyFile: keyPath, wantErr: true},
+		{name: "path traversal in key", certFile: certPath, keyFile: "/boot/../etc/key.pem", wantErr: true},
+		{name: "null byte in cert", certFile: "/boot/cert\x00.pem", keyFile: keyPath, wantErr: true},
+		{name: "missing files but valid paths", certFile: "/nonexistent/cert.pem", keyFile: "/nonexistent/key.pem", wantErr: true},
+		{name: "key file is not a key pair", certFile: certPath, keyFile: certPath, wantErr: true},
+		{name: "over-long cert path", certFile: "/" + strings.Repeat("a", maxTLSPathLen), keyFile: keyPath, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTLSConfig(tt.certFile, tt.keyFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateTLSConfig(%q, %q) error = %v, wantErr %v", tt.certFile, tt.keyFile, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/daemon/services/api/handlers.go
+++ b/daemon/services/api/handlers.go
@@ -408,8 +408,7 @@ func (s *Server) handleNetwork(w http.ResponseWriter, _ *http.Request) {
 //	@Success		200	{object}	dto.NetworkAccessURLs	"Network access URLs"
 //	@Router			/network/access-urls [get]
 func (s *Server) handleNetworkAccessURLs(w http.ResponseWriter, _ *http.Request) {
-	accessURLs := collectors.CollectNetworkAccessURLs()
-	respondJSON(w, http.StatusOK, accessURLs)
+	respondJSON(w, http.StatusOK, s.GetNetworkAccessURLs())
 }
 
 // Generic Docker operation handler to reduce code duplication

--- a/daemon/services/api/server.go
+++ b/daemon/services/api/server.go
@@ -420,6 +420,11 @@ func (s *Server) StartHTTP() error {
 		IdleTimeout:       120 * time.Second,
 	}
 
+	if s.ctx.TLSEnabled() {
+		logger.Info("HTTPS server listening on %s", s.httpServer.Addr)
+		return s.httpServer.ListenAndServeTLS(s.ctx.TLSCertFile, s.ctx.TLSKeyFile)
+	}
+
 	logger.Info("HTTP server listening on %s", s.httpServer.Addr)
 	return s.httpServer.ListenAndServe()
 }
@@ -614,9 +619,14 @@ func (s *Server) GetShareConfig(name string) *dto.ShareConfig {
 	return config
 }
 
-// GetNetworkAccessURLs returns all network access URLs for the server.
+// GetNetworkAccessURLs returns all network access URLs for the server. When the
+// agent serves HTTPS the URLs are rewritten to https:// with the configured
+// port, so clients are pointed at the scheme the server actually listens on.
 func (s *Server) GetNetworkAccessURLs() *dto.NetworkAccessURLs {
 	accessURLs := collectors.CollectNetworkAccessURLs()
+	if s.ctx.TLSEnabled() {
+		accessURLs.URLs = collectors.GetHTTPSURLs(accessURLs.URLs, s.ctx.Port)
+	}
 	return accessURLs
 }
 

--- a/daemon/services/discovery/service.go
+++ b/daemon/services/discovery/service.go
@@ -27,6 +27,7 @@ type Service struct {
 	port        int
 	version     string
 	bindAddress string
+	tlsEnabled  bool
 
 	mu     sync.Mutex
 	server *zeroconf.Server
@@ -37,14 +38,16 @@ type Service struct {
 // the agent version string and bindAddress is the HTTP server's configured bind
 // address (empty = all interfaces). When a specific bind address is set it is
 // advertised instead of the auto-detected primary IP, so discovery always
-// points at the endpoint the server actually listens on.
-func NewService(config domain.DiscoveryConfig, hostname string, port int, version string, bindAddress string) *Service {
+// points at the endpoint the server actually listens on. tlsEnabled reports
+// whether the agent serves HTTPS, so discovery consumers learn the scheme.
+func NewService(config domain.DiscoveryConfig, hostname string, port int, version string, bindAddress string, tlsEnabled bool) *Service {
 	return &Service{
 		config:      config,
 		hostname:    hostname,
 		port:        port,
 		version:     version,
 		bindAddress: bindAddress,
+		tlsEnabled:  tlsEnabled,
 	}
 }
 
@@ -61,10 +64,15 @@ func (s *Service) instanceName() string {
 // integrations rich metadata (version + API path + friendly name) without an
 // extra HTTP round-trip during discovery.
 func (s *Service) txtRecords() []string {
+	scheme := "http"
+	if s.tlsEnabled {
+		scheme = "https"
+	}
 	return []string{
 		"version=" + s.version,
 		"path=/api/v1",
 		"name=" + s.hostname,
+		"scheme=" + scheme,
 	}
 }
 

--- a/daemon/services/discovery/service_test.go
+++ b/daemon/services/discovery/service_test.go
@@ -65,7 +65,7 @@ func TestInstanceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewService(tt.config, tt.hostname, 8043, "2026.06.01", "")
+			s := NewService(tt.config, tt.hostname, 8043, "2026.06.01", "", false)
 			if got := s.instanceName(); got != tt.want {
 				t.Errorf("instanceName() = %q, want %q", got, tt.want)
 			}
@@ -74,22 +74,43 @@ func TestInstanceName(t *testing.T) {
 }
 
 func TestTxtRecords(t *testing.T) {
-	s := NewService(domain.DiscoveryConfig{Enabled: true}, "tower", 8043, "2026.06.01", "")
-	got := s.txtRecords()
-
-	want := []string{"version=2026.06.01", "path=/api/v1", "name=tower"}
-	if len(got) != len(want) {
-		t.Errorf("txtRecords() returned %d records (%v), want %d (%v)", len(got), got, len(want), want)
+	tests := []struct {
+		name       string
+		tlsEnabled bool
+		wantScheme string
+	}{
+		{name: "plain HTTP advertises scheme=http", tlsEnabled: false, wantScheme: "scheme=http"},
+		{name: "TLS enabled advertises scheme=https", tlsEnabled: true, wantScheme: "scheme=https"},
 	}
-	for _, rec := range want {
-		if !slices.Contains(got, rec) {
-			t.Errorf("txtRecords() = %v, missing %q", got, rec)
-		}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewService(domain.DiscoveryConfig{Enabled: true}, "tower", 8043, "2026.06.01", "", tt.tlsEnabled)
+			got := s.txtRecords()
+
+			want := []string{"version=2026.06.01", "path=/api/v1", "name=tower", tt.wantScheme}
+			if len(got) != len(want) {
+				t.Errorf("txtRecords() returned %d records (%v), want %d (%v)", len(got), got, len(want), want)
+			}
+			for _, rec := range want {
+				if !slices.Contains(got, rec) {
+					t.Errorf("txtRecords() = %v, missing %q", got, rec)
+				}
+			}
+			// The opposite scheme must never appear.
+			otherScheme := "scheme=https"
+			if tt.tlsEnabled {
+				otherScheme = "scheme=http"
+			}
+			if slices.Contains(got, otherScheme) {
+				t.Errorf("txtRecords() = %v, must not contain %q", got, otherScheme)
+			}
+		})
 	}
 }
 
 func TestShutdownWithoutStartIsSafe(t *testing.T) {
-	s := NewService(domain.DiscoveryConfig{Enabled: true}, "tower", 8043, "2026.06.01", "")
+	s := NewService(domain.DiscoveryConfig{Enabled: true}, "tower", 8043, "2026.06.01", "", false)
 	// Shutdown before Start must be a no-op and must not panic.
 	s.Shutdown()
 }
@@ -120,7 +141,7 @@ func TestAdvertiseIP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewService(domain.DiscoveryConfig{Enabled: true}, "tower", 8043, "2026.06.01", tt.bindAddress)
+			s := NewService(domain.DiscoveryConfig{Enabled: true}, "tower", 8043, "2026.06.01", tt.bindAddress, false)
 			got := s.advertiseIP()
 			if tt.wantFixed != "" {
 				if got == nil || got.String() != tt.wantFixed {
@@ -140,7 +161,7 @@ func TestAdvertiseIP(t *testing.T) {
 func TestStartSkipsAdvertisementOnLoopbackBind(t *testing.T) {
 	for _, bindAddr := range []string{"127.0.0.1", "127.0.0.53", "::1"} {
 		t.Run(bindAddr, func(t *testing.T) {
-			s := NewService(domain.DiscoveryConfig{Enabled: true}, "tower", 8043, "2026.06.01", bindAddr)
+			s := NewService(domain.DiscoveryConfig{Enabled: true}, "tower", 8043, "2026.06.01", bindAddr, false)
 			if err := s.Start(context.Background()); err != nil {
 				t.Fatalf("Start() with loopback bind %q returned error: %v", bindAddr, err)
 			}

--- a/daemon/services/orchestrator.go
+++ b/daemon/services/orchestrator.go
@@ -248,7 +248,11 @@ func (o *Orchestrator) Run() error {
 		}
 	})
 
-	logger.Success("API server started on port %d", o.ctx.Port)
+	scheme := "http"
+	if o.ctx.TLSEnabled() {
+		scheme = "https"
+	}
+	logger.Success("API server started on %s port %d (MCP endpoint: %s://<host>:%d/mcp)", scheme, o.ctx.Port, scheme, o.ctx.Port)
 	logger.Success("Agent startup complete")
 
 	// Wait for shutdown signal
@@ -463,7 +467,7 @@ func (o *Orchestrator) initializeDiscovery(ctx context.Context) {
 		hostname = "unraid"
 	}
 
-	svc := discovery.NewService(o.ctx.DiscoveryConfig, hostname, o.ctx.Port, o.ctx.Version, o.ctx.BindAddress)
+	svc := discovery.NewService(o.ctx.DiscoveryConfig, hostname, o.ctx.Port, o.ctx.Version, o.ctx.BindAddress, o.ctx.TLSEnabled())
 	if err := svc.Start(ctx); err != nil {
 		logger.Warning("Discovery service disabled: %v", err)
 		return

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -383,6 +383,39 @@ grep DEBUG /var/log/unraid-management-agent.log
 - Use WireGuard VPN for remote access
 - Use reverse proxy with authentication (nginx, Traefik)
 
+### HTTPS / TLS
+
+By default the agent serves plain HTTP. You can have it serve HTTPS natively
+(including the `/mcp` endpoint) by pointing it at a PEM certificate/key pair.
+TLS is enabled only when **both** files are configured; supplying just one, or
+an unreadable cert, logs a warning and falls back to plain HTTP so a stale path
+can never make the agent unreachable.
+
+| Setting          | CLI flag          | Env var         | Config key      |
+| ---------------- | ----------------- | --------------- | --------------- |
+| Certificate file | `--tls-cert-file` | `TLS_CERT_FILE` | `tls_cert_file` |
+| Private key file | `--tls-key-file`  | `TLS_KEY_FILE`  | `tls_key_file`  |
+
+Both paths must be absolute. Example (`config.yml`):
+
+```yaml
+tls_cert_file: /boot/config/ssl/certs/certificate_bundle.pem
+tls_key_file: /boot/config/ssl/certs/certificate_bundle.pem
+```
+
+Point these at a **publicly-trusted** certificate — for example Unraid's own
+`*.myunraid.net` Let's Encrypt bundle under `/boot/config/ssl/certs/` (Unraid
+ships the cert and key concatenated in a single `*_unraid_bundle.pem`, so the
+same path can be used for both). Self-signed certificates work for browsers and
+`curl -k`, but are **not** accepted by hosted clients such as Claude Desktop.
+
+> [!NOTE]
+> Claude Desktop / claude.ai "Custom Connectors" are reached from Anthropic's
+> cloud, so native HTTPS alone is not enough — the endpoint must also be
+> reachable from the public internet (port-forward or tunnel) with a trusted
+> cert. For LAN-only use, the `mcp-remote` bridge needs no TLS at all. See the
+> [Claude integration guide](../integrations/claude/README.md#2-connect-claude-to-your-server-mcp).
+
 ### Authentication (Future)
 
 Authentication is planned for future versions. Current options:

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -409,10 +409,11 @@ tls_key_file: /boot/config/ssl/certs/certificate_bundle.pem
 ```
 
 Point these at a **publicly-trusted** certificate — for example Unraid's own
-`*.myunraid.net` Let's Encrypt bundle under `/boot/config/ssl/certs/` (Unraid
-ships the cert and key concatenated in a single `*_unraid_bundle.pem`, so the
-same path can be used for both). Self-signed certificates work for browsers and
-`curl -k`, but are **not** accepted by hosted clients such as Claude Desktop.
+`*.myunraid.net` Let's Encrypt certificate, which Unraid maintains as a combined
+cert+key bundle at `/boot/config/ssl/certs/certificate_bundle.pem` (the same
+path used in the example above for both keys). Self-signed certificates work for
+browsers and `curl -k`, but are **not** accepted by hosted clients such as
+Claude Desktop.
 
 > [!NOTE]
 > Claude Desktop / claude.ai "Custom Connectors" are reached from Anthropic's

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -387,16 +387,21 @@ grep DEBUG /var/log/unraid-management-agent.log
 
 By default the agent serves plain HTTP. You can have it serve HTTPS natively
 (including the `/mcp` endpoint) by pointing it at a PEM certificate/key pair.
-TLS is enabled only when **both** files are configured; supplying just one, or
-an unreadable cert, logs a warning and falls back to plain HTTP so a stale path
-can never make the agent unreachable.
+TLS is enabled only when **both** files are configured. If only one is set, or
+either file is missing, unreadable, or not a valid certificate/key pair, the
+agent logs a warning and falls back to plain HTTP so a stale path can never make
+it unreachable.
 
 | Setting          | CLI flag          | Env var         | Config key      |
 | ---------------- | ----------------- | --------------- | --------------- |
 | Certificate file | `--tls-cert-file` | `TLS_CERT_FILE` | `tls_cert_file` |
 | Private key file | `--tls-key-file`  | `TLS_KEY_FILE`  | `tls_key_file`  |
 
-Both paths must be absolute. Example (`config.yml`):
+Both paths must be absolute. The cert and key may live in separate files or in a
+single combined PEM bundle — Go reads the certificate from `tls_cert_file` and
+the private key from `tls_key_file`, so pointing **both** at one bundle that
+contains the cert and key is valid. Example (`config.yml`) using Unraid's
+combined bundle for both:
 
 ```yaml
 tls_cert_file: /boot/config/ssl/certs/certificate_bundle.pem

--- a/docs/integrations/claude/README.md
+++ b/docs/integrations/claude/README.md
@@ -34,15 +34,69 @@ Settings → Capabilities → Skills (see `skills/README.md`).
 
 ## 2. Connect Claude to your server (MCP)
 
-- **Claude Code:**
+The agent serves a Streamable HTTP MCP endpoint at `/mcp`. How you connect
+depends on the client:
 
-  ```bash
-  claude mcp add --transport http unraid http://<unraid-ip>:8043/mcp
-  ```
+### Claude Code
 
-- **Claude Desktop / claude.ai:** add a custom MCP connector with URL
-  `http://<unraid-ip>:8043/mcp`.
-- **Local (on the Unraid box):** use STDIO — `unraid-management-agent mcp-stdio`.
+Claude Code accepts an HTTP URL directly:
+
+```bash
+claude mcp add --transport http unraid http://<unraid-ip>:8043/mcp
+```
+
+### Claude Desktop / claude.ai — "Custom Connector"
+
+> [!IMPORTANT]
+> A custom connector is reached **from Anthropic's cloud, not from your
+> computer.** Anthropic requires the URL to be **HTTPS with a publicly-trusted
+> certificate**, and the server must be **reachable from the public internet**.
+> A LAN address such as `http://<unraid-ip>:8043/mcp` (or even `https://` with a
+> self-signed cert) is rejected — you'll see _"URL must start with https"_ or
+> _"our servers cannot reach your local machine."_ This is the cause of
+> [#131](https://github.com/ruaan-deysel/unraid-management-agent/issues/131).
+
+To use a custom connector you must expose the agent over **public HTTPS with a
+trusted cert**, via either:
+
+- **Native HTTPS** — point the agent at a trusted certificate (e.g. Unraid's
+  `myunraid.net` cert) with `--tls-cert-file` / `--tls-key-file` (see
+  [configuration guide](../../guides/configuration.md#https--tls)), then
+  port-forward or tunnel `https://<public-host>:8043/mcp`.
+- **A reverse proxy or tunnel** that terminates a trusted cert in front of the
+  agent — e.g. SWAG/Nginx Proxy Manager, Cloudflare Tunnel, or Tailscale Funnel.
+
+Then in **Settings → Connectors → Add custom connector**, enter the public
+`https://…/mcp` URL.
+
+### Claude Desktop on a LAN (no public exposure) — `mcp-remote` bridge
+
+If you only use the agent on your local network, the simplest option is the
+[`mcp-remote`](https://www.npmjs.com/package/mcp-remote) stdio bridge. Claude
+Desktop speaks stdio to `mcp-remote`, which runs on your computer and talks to
+the agent over the LAN — so plain HTTP and a LAN IP work fine. Requires
+[Node.js](https://nodejs.org). Edit `claude_desktop_config.json` (Settings →
+Developer → Edit Config) and add:
+
+```json
+{
+  "mcpServers": {
+    "unraid": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://<unraid-ip>:8043/mcp", "--allow-http", "--transport", "http-only"]
+    }
+  }
+}
+```
+
+`--allow-http` permits the plain-HTTP LAN connection (use only on a trusted
+network) and `--transport http-only` matches the agent's Streamable HTTP
+endpoint (it has no SSE half, so this avoids a startup delay). Restart Claude
+Desktop after saving.
+
+### Local, on the Unraid box itself
+
+Use STDIO — `unraid-management-agent mcp-stdio`. No URL, no TLS.
 
 Details and per-client config: [`../mcp.md`](../mcp.md) and the skill's
 [`references/connection.md`](../../../skills/unraid-management-agent/references/connection.md).

--- a/docs/integrations/claude/README.md
+++ b/docs/integrations/claude/README.md
@@ -45,8 +45,11 @@ Claude Code accepts the URL directly:
 claude mcp add --transport http unraid http://<unraid-ip>:8043/mcp
 ```
 
-If you've enabled native TLS (`--tls-cert-file`/`--tls-key-file`), use the
-matching `https://<unraid-ip>:8043/mcp` URL instead.
+If you've enabled native TLS (`--tls-cert-file`/`--tls-key-file`), use `https://`
+with the hostname the certificate is issued for (e.g.
+`https://<server>.myunraid.net:8043/mcp`) — a trusted cert validates against its
+hostname, so a raw `https://<ip>` URL only works if the certificate includes
+that IP as a Subject Alternative Name.
 
 ### Claude Desktop / claude.ai — "Custom Connector"
 

--- a/docs/integrations/claude/README.md
+++ b/docs/integrations/claude/README.md
@@ -39,11 +39,14 @@ depends on the client:
 
 ### Claude Code
 
-Claude Code accepts an HTTP URL directly:
+Claude Code accepts the URL directly:
 
 ```bash
 claude mcp add --transport http unraid http://<unraid-ip>:8043/mcp
 ```
+
+If you've enabled native TLS (`--tls-cert-file`/`--tls-key-file`), use the
+matching `https://<unraid-ip>:8043/mcp` URL instead.
 
 ### Claude Desktop / claude.ai — "Custom Connector"
 

--- a/main.go
+++ b/main.go
@@ -63,6 +63,10 @@ var cli struct {
 	// CORS
 	CORSOrigin string `default:"*" env:"CORS_ORIGIN" help:"Access-Control-Allow-Origin value (default: *)"`
 
+	// TLS: serve HTTPS (incl. the /mcp endpoint) when both files are provided
+	TLSCertFile string `default:"" env:"TLS_CERT_FILE" help:"path to a PEM TLS certificate file (enables HTTPS when set with --tls-key-file)"`
+	TLSKeyFile  string `default:"" env:"TLS_KEY_FILE" help:"path to a PEM TLS private key file (enables HTTPS when set with --tls-cert-file)"`
+
 	// Low power mode - multiplies all intervals for resource-constrained systems
 	LowPowerMode bool `default:"false" env:"UNRAID_LOW_POWER" help:"enable low power mode (4x longer intervals for old/slow hardware)"`
 
@@ -214,6 +218,18 @@ func main() {
 		}
 	}
 
+	// Validate TLS configuration. A bad or half-configured cert/key pair falls
+	// back to plain HTTP rather than refusing to start, mirroring the bind
+	// address behaviour, so a stale cert path can never make the agent
+	// unreachable. ValidateTLSConfig treats an empty pair as "TLS disabled".
+	if err := lib.ValidateTLSConfig(cli.TLSCertFile, cli.TLSKeyFile); err != nil {
+		logger.Warning("%v; serving plain HTTP", err)
+		cli.TLSCertFile = ""
+		cli.TLSKeyFile = ""
+	} else if cli.TLSCertFile != "" {
+		logger.Info("HTTPS enabled (certificate: %s)", cli.TLSCertFile)
+	}
+
 	if cli.ReadOnly {
 		logger.Info("Read-only mode enabled: all state-changing MCP tools are blocked")
 	}
@@ -269,6 +285,8 @@ func main() {
 			BindAddress: cli.BindAddress,
 			CORSOrigin:  cli.CORSOrigin,
 			ReadOnly:    cli.ReadOnly,
+			TLSCertFile: cli.TLSCertFile,
+			TLSKeyFile:  cli.TLSKeyFile,
 		},
 		Hub:      domain.NewEventBus(1024), // Buffer size for event bus
 		Platform: platform.NewRegistry(),
@@ -368,6 +386,8 @@ func applyFileConfig(cfg *domain.FileConfig) {
 	setBool(&cli.LowPowerMode, cfg.LowPowerMode)
 	setStr(&cli.DisableCollectors, cfg.DisableCollectors)
 	setStr(&cli.CORSOrigin, cfg.CORSOrigin)
+	setStr(&cli.TLSCertFile, cfg.TLSCertFile)
+	setStr(&cli.TLSKeyFile, cfg.TLSKeyFile)
 
 	// MQTT
 	if m := cfg.MQTT; m != nil {

--- a/main.go
+++ b/main.go
@@ -226,7 +226,7 @@ func main() {
 		logger.Warning("TLS is configured but invalid (%v); falling back to plain HTTP — the server will NOT be encrypted. Fix the certificate/key paths or remove the TLS settings.", err)
 		cli.TLSCertFile = ""
 		cli.TLSKeyFile = ""
-	} else if cli.TLSCertFile != "" {
+	} else if cli.TLSCertFile != "" && cli.TLSKeyFile != "" {
 		logger.Info("HTTPS enabled (certificate: %s)", cli.TLSCertFile)
 	}
 

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func main() {
 	// address behaviour, so a stale cert path can never make the agent
 	// unreachable. ValidateTLSConfig treats an empty pair as "TLS disabled".
 	if err := lib.ValidateTLSConfig(cli.TLSCertFile, cli.TLSKeyFile); err != nil {
-		logger.Warning("%v; serving plain HTTP", err)
+		logger.Warning("TLS is configured but invalid (%v); falling back to plain HTTP — the server will NOT be encrypted. Fix the certificate/key paths or remove the TLS settings.", err)
 		cli.TLSCertFile = ""
 		cli.TLSKeyFile = ""
 	} else if cli.TLSCertFile != "" {


### PR DESCRIPTION
## Summary

Fixes #131 — Claude Desktop could not add the agent because its `/mcp` endpoint was plain HTTP only.

While implementing this I verified the **actual** Claude Desktop connector requirements (Anthropic support docs + GitHub issues with Anthropic staff replies). This corrected the original plan in two important ways:

- **Custom Connectors are reached from Anthropic's cloud, not your machine.** So native HTTPS alone does **not** make a LAN URL work — a private IP is unreachable from Anthropic's servers, and a trusted cert validates against a hostname (not an IP). The docs therefore lead with the path that actually works for LAN users.
- **Self-signed certs are rejected** by hosted clients.

## What's in here

**Native HTTPS/TLS** for the REST API and the `/mcp` endpoint:
- `--tls-cert-file` / `--tls-key-file` (env `TLS_CERT_FILE` / `TLS_KEY_FILE`, or `tls_cert_file` / `tls_key_file` in `config.yml`).
- `StartHTTP()` serves `ListenAndServeTLS` when both are set; otherwise unchanged plain HTTP.
- **Invalid / half-configured / unloadable TLS logs a warning and falls back to plain HTTP** so a stale cert path can never make the agent unreachable (mirrors the existing `BindAddress` behaviour).
- `lib.ValidateTLSConfig`: both-required + per-path guards (length, null-byte CWE-158, `..` segment CWE-22, absolute) + `LoadX509KeyPair`.

**Scheme-aware advertisement:**
- mDNS TXT now includes `scheme=https` / `scheme=http`.
- `/network/access-urls` returns `https://` URLs when TLS is active (wires the previously-unused `GetHTTPSURLs` helper).

**Docs:**
- `docs/integrations/claude/README.md` — explains the cloud-reachability requirement and documents the working paths: `mcp-remote --allow-http` stdio bridge for LAN-only use (no TLS), and native HTTPS / reverse proxy / tunnel with a trusted cert for Custom Connectors.
- `docs/guides/configuration.md` — new HTTPS / TLS section.
- `CHANGELOG.md` — `Added` + `Fixed` under `[Unreleased]`.

## Testing

- Full Go test suite: 22 packages, 0 failures. New tests for `ValidateTLSConfig` (incl. traversal/injection/positive dotted-component cases), `Config.TLSEnabled()`, and the discovery `scheme=` TXT record.
- CodeRabbit CLI review (3 rounds) — all actionable findings addressed.
- **Verified on Unraid 7.3.1 hardware:** `build,deploy,verify` playbook passed (`failed=0`, MCP protocol init/tools/resources/prompts/call/read ✓); an isolated on-box run confirmed `/mcp` serves over HTTPS (valid MCP `initialize` response) with plain HTTP correctly rejected and the live `:8043` service untouched.

## Deliberate design notes

- **Warn + fall back to HTTP** (rather than fail-closed) on invalid TLS — keeps the monitoring agent reachable and returns to its documented default LAN/HTTP posture.
- TLS config plumbing mirrors the established `applyFileConfig` layering used by every other setting.

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native HTTPS/TLS support for the REST API and MCP endpoint when valid certificate and key files are configured.
  * Updated network access URLs and discovery details to reflect the active HTTP or HTTPS scheme.
* **Bug Fixes**
  * Improved handling of invalid or partial TLS settings by falling back to plain HTTP and logging a warning.
  * Clarified Claude Desktop connection guidance, including LAN-only and public connector setup options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->