### PR TITLE
fix(notifications): stock-format .notify files (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Agent-created notifications no longer crash the stock notification parser** (#134) —
+  `CreateNotification` now writes `.notify` files in a stock-compatible format matching
+  the webGui `notify` script's output: an unquoted unix-epoch `timestamp` as the first
+  line (the stock PHP parser blindly `date()`-formats the first value, so the old
+  `event="..."` first line caused a fatal TypeError that killed every notification
+  poll), stock field order and value escaping, a stock-style `safe_filename()` file
+  name (`Event_Name_<epoch>.notify`), and an archive copy written first (archiving now
+  removes the unread file and keeps that copy, like the stock `archive` verb). Files
+  are written atomically (temp file + rename, cleaned up on failure), so a full disk
+  can no longer leave 0-byte `.notify` files that the UI flags as invalid
+  notifications. The notification collector now parses stock-format files (unquoted
+  epoch timestamps, escaped values) while still reading the legacy quoted-datetime
+  format.
+
 ## [2026.06.10] - 2026-06-26
 
 ### Added

--- a/daemon/services/api/handlers_coverage_test.go
+++ b/daemon/services/api/handlers_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -763,6 +764,9 @@ func TestHandleCreateNotification_MissingTitle(t *testing.T) {
 }
 
 func TestHandleCreateNotification_ValidNotification(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("as root this would create real files under /boot (controllers notification dirs are not overridable from this package)")
+	}
 	server, _ := setupTestServer()
 
 	body := `{"title":"Test Alert","subject":"Test","description":"Test notification","importance":"warning","link":"https://example.com"}`
@@ -785,6 +789,9 @@ func TestHandleCreateNotification_ValidNotification(t *testing.T) {
 }
 
 func TestHandleCreateNotification_DefaultImportance(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("as root this would create real files under /boot (controllers notification dirs are not overridable from this package)")
+	}
 	server, _ := setupTestServer()
 
 	// When importance is omitted, it should default to "info"

--- a/daemon/services/collectors/notification.go
+++ b/daemon/services/collectors/notification.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -228,7 +229,7 @@ func (c *NotificationCollector) parseNotificationFile(path string, notifType str
 		}
 
 		key := strings.TrimSpace(parts[0])
-		value := strings.Trim(strings.TrimSpace(parts[1]), `"`)
+		value := iniDecodeValue(parts[1])
 
 		switch key {
 		case "event":
@@ -240,7 +241,19 @@ func (c *NotificationCollector) parseNotificationFile(path string, notifType str
 		case "importance":
 			notification.Importance = value
 		case "timestamp":
-			if ts, err := time.Parse("2006-01-02 15:04:05", value); err == nil {
+			// Stock notify files carry an unquoted unix epoch; agent versions
+			// before the issue #134 fix wrote a quoted datetime string. Bound
+			// the epoch to years [1970,9999]: a rogue value (e.g. a millisecond
+			// epoch) would yield a time.Time that fails JSON marshaling and
+			// kill encoding of the whole NotificationList. MarshalJSON checks
+			// the year in the time's own location, so the local year must be
+			// checked too: near the cap, east-of-UTC hosts render year 10000.
+			// (The epoch cap runs first so time.Unix cannot overflow.)
+			if epoch, err := strconv.ParseInt(value, 10, 64); err == nil && epoch >= 0 && epoch <= 253402300799 &&
+				time.Unix(epoch, 0).Year() <= 9999 {
+				notification.Timestamp = time.Unix(epoch, 0)
+				notification.FormattedTimestamp = notification.Timestamp.Format(time.RFC3339)
+			} else if ts, err := time.Parse("2006-01-02 15:04:05", value); err == nil {
 				notification.Timestamp = ts
 				notification.FormattedTimestamp = ts.Format(time.RFC3339)
 			}
@@ -258,6 +271,37 @@ func (c *NotificationCollector) parseNotificationFile(path string, notifType str
 	}
 
 	return notification
+}
+
+// iniDecodeValue mirrors the stock notify script's ini_decode_value(): trim
+// whitespace and, when the value is wrapped in double quotes, unwrap it and
+// remove the backslash escaping added by the stock ini_encode_value().
+func iniDecodeValue(raw string) string {
+	v := strings.TrimSpace(raw)
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		return stripSlashes(v[1 : len(v)-1])
+	}
+	return v
+}
+
+// stripSlashes mirrors PHP's stripslashes(): a backslash escapes the character
+// that follows it; a trailing lone backslash is dropped.
+func stripSlashes(s string) string {
+	if !strings.Contains(s, "\\") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' {
+			i++
+			if i == len(s) {
+				break
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
 }
 
 // calculateOverview calculates notification counts by type and importance

--- a/daemon/services/collectors/notification.go
+++ b/daemon/services/collectors/notification.go
@@ -245,13 +245,12 @@ func (c *NotificationCollector) parseNotificationFile(path string, notifType str
 			// before the issue #134 fix wrote a quoted datetime string. Bound
 			// the epoch to years [1970,9999]: a rogue value (e.g. a millisecond
 			// epoch) would yield a time.Time that fails JSON marshaling and
-			// kill encoding of the whole NotificationList. MarshalJSON checks
-			// the year in the time's own location, so the local year must be
-			// checked too: near the cap, east-of-UTC hosts render year 10000.
-			// (The epoch cap runs first so time.Unix cannot overflow.)
-			if epoch, err := strconv.ParseInt(value, 10, 64); err == nil && epoch >= 0 && epoch <= 253402300799 &&
-				time.Unix(epoch, 0).Year() <= 9999 {
-				notification.Timestamp = time.Unix(epoch, 0)
+			// kill encoding of the whole NotificationList. The value is stored
+			// as UTC, so the cap (9999-12-31T23:59:59Z) alone bounds the year
+			// MarshalJSON validates, and every parse path renders the same
+			// Z-suffixed RFC3339 form regardless of host timezone.
+			if epoch, err := strconv.ParseInt(value, 10, 64); err == nil && epoch >= 0 && epoch <= 253402300799 {
+				notification.Timestamp = time.Unix(epoch, 0).UTC()
 				notification.FormattedTimestamp = notification.Timestamp.Format(time.RFC3339)
 			} else if ts, err := time.Parse("2006-01-02 15:04:05", value); err == nil {
 				notification.Timestamp = ts
@@ -265,8 +264,8 @@ func (c *NotificationCollector) parseNotificationFile(path string, notifType str
 	// If timestamp wasn't parsed, use file modification time
 	if notification.Timestamp.IsZero() {
 		if info, err := os.Stat(path); err == nil {
-			notification.Timestamp = info.ModTime()
-			notification.FormattedTimestamp = info.ModTime().Format(time.RFC3339)
+			notification.Timestamp = info.ModTime().UTC()
+			notification.FormattedTimestamp = notification.Timestamp.Format(time.RFC3339)
 		}
 	}
 

--- a/daemon/services/collectors/notification_test.go
+++ b/daemon/services/collectors/notification_test.go
@@ -2,6 +2,7 @@ package collectors
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -435,5 +436,88 @@ func TestNotificationCollectorPanic(t *testing.T) {
 
 	if panicOccurred {
 		t.Error("Unexpected panic occurred")
+	}
+}
+
+// TestParseNotificationFile_StockFormat verifies the parser understands the
+// stock notify script format (unquoted unix-epoch timestamp, backslash-escaped
+// quoted values) while still parsing the legacy quoted-datetime format written
+// by older agent versions (issue #134).
+func TestParseNotificationFile_StockFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name      string
+		content   string
+		checkFunc func(*dto.Notification) bool
+	}{
+		{
+			name:    "unquoted epoch timestamp",
+			content: "timestamp=1751500000\nevent=\"Test\"\nsubject=\"S\"\ndescription=\"D\"\nimportance=\"warning\"\nlink=\"\"\n",
+			checkFunc: func(n *dto.Notification) bool {
+				return n != nil && n.Timestamp.Unix() == 1751500000 &&
+					n.FormattedTimestamp == time.Unix(1751500000, 0).Format(time.RFC3339)
+			},
+		},
+		{
+			name:    "legacy quoted datetime timestamp",
+			content: "event=\"Test\"\nsubject=\"S\"\ndescription=\"D\"\nimportance=\"warning\"\ntimestamp=\"2026-07-03 15:20:00\"\nlink=\"\"\n",
+			checkFunc: func(n *dto.Notification) bool {
+				want, _ := time.Parse("2006-01-02 15:04:05", "2026-07-03 15:20:00")
+				return n != nil && n.Timestamp.Equal(want)
+			},
+		},
+		{
+			name:    "escaped quotes and backslashes in values",
+			content: "timestamp=1751500000\nevent=\"Test\"\nsubject=\"Say \\\"hi\\\"\"\ndescription=\"back\\\\slash\"\nimportance=\"warning\"\nlink=\"\"\n",
+			checkFunc: func(n *dto.Notification) bool {
+				return n != nil && n.Subject == `Say "hi"` && n.Description == `back\slash`
+			},
+		},
+		{
+			// A millisecond epoch (or any value past year 9999) must fall back
+			// to the file's mtime: a time.Time outside years [0,9999] fails
+			// JSON marshaling and would kill the whole NotificationList.
+			name:    "out-of-range epoch falls back to mtime",
+			content: "timestamp=1751500000000\nevent=\"Test\"\nsubject=\"S\"\ndescription=\"D\"\nimportance=\"warning\"\nlink=\"\"\n",
+			checkFunc: func(n *dto.Notification) bool {
+				st, err := os.Stat(filepath.Join(tmpDir, "stock-format-test.notify"))
+				return err == nil && n != nil && n.Timestamp.Equal(st.ModTime())
+			},
+		},
+		{
+			// 9999-12-31T23:59:59Z. MarshalJSON validates the year in the
+			// time's own location, so whatever the host timezone, an accepted
+			// epoch must produce a marshalable notification.
+			name:    "epoch at the marshalable boundary",
+			content: "timestamp=253402300799\nevent=\"Test\"\nsubject=\"S\"\ndescription=\"D\"\nimportance=\"warning\"\nlink=\"\"\n",
+			checkFunc: func(n *dto.Notification) bool {
+				if n == nil {
+					return false
+				}
+				_, err := json.Marshal(n)
+				return err == nil
+			},
+		},
+	}
+
+	hub := domain.NewEventBus(10)
+	ctx := &domain.Context{Hub: hub}
+	collector := NewNotificationCollector(ctx)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(tmpDir, "stock-format-test.notify")
+			if err := os.WriteFile(filePath, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("Failed to write test file: %v", err)
+			}
+			defer os.Remove(filePath) //nolint:errcheck
+
+			notif := collector.parseNotificationFile(filePath, "unread")
+
+			if !tt.checkFunc(notif) {
+				t.Errorf("Notification check failed: %+v", notif)
+			}
+		})
 	}
 }

--- a/daemon/services/collectors/notification_test.go
+++ b/daemon/services/collectors/notification_test.go
@@ -455,8 +455,10 @@ func TestParseNotificationFile_StockFormat(t *testing.T) {
 			name:    "unquoted epoch timestamp",
 			content: "timestamp=1751500000\nevent=\"Test\"\nsubject=\"S\"\ndescription=\"D\"\nimportance=\"warning\"\nlink=\"\"\n",
 			checkFunc: func(n *dto.Notification) bool {
+				// Host-independent literal: timestamps are stored as UTC so
+				// every parse path renders the same Z-suffixed RFC3339 form.
 				return n != nil && n.Timestamp.Unix() == 1751500000 &&
-					n.FormattedTimestamp == time.Unix(1751500000, 0).Format(time.RFC3339)
+					n.FormattedTimestamp == "2025-07-02T23:46:40Z"
 			},
 		},
 		{
@@ -492,7 +494,7 @@ func TestParseNotificationFile_StockFormat(t *testing.T) {
 			name:    "epoch at the marshalable boundary",
 			content: "timestamp=253402300799\nevent=\"Test\"\nsubject=\"S\"\ndescription=\"D\"\nimportance=\"warning\"\nlink=\"\"\n",
 			checkFunc: func(n *dto.Notification) bool {
-				if n == nil {
+				if n == nil || n.Timestamp.Unix() != 253402300799 {
 					return false
 				}
 				_, err := json.Marshal(n)

--- a/daemon/services/controllers/notification.go
+++ b/daemon/services/controllers/notification.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -243,7 +244,11 @@ func writeFileAtomic(dir, name string, content []byte) error {
 		return err
 	}
 	tmpName := tmp.Name()
-	_, err = tmp.Write(content)
+	n, err := tmp.Write(content)
+	if err == nil && n < len(content) {
+		// Belt-and-braces like os.WriteFile: surface a short write as an error.
+		err = io.ErrShortWrite
+	}
 	if closeErr := tmp.Close(); err == nil {
 		err = closeErr
 	}

--- a/daemon/services/controllers/notification.go
+++ b/daemon/services/controllers/notification.go
@@ -103,16 +103,7 @@ func ArchiveNotification(id string) error {
 		return fmt.Errorf("failed to create archive directory: %w", err)
 	}
 
-	// Since the issue #134 fix an archive copy (without link) is written at
-	// creation, so archiving normally only needs to remove the unread file,
-	// like the stock notify script's 'archive' verb; renaming over the copy
-	// would clobber it. Fall back to a rename for files with no archive copy.
-	if _, err := os.Stat(dst); err == nil {
-		if err := os.Remove(src); err != nil {
-			logger.Error("Failed to archive notification %s: %v", id, err)
-			return fmt.Errorf("failed to archive notification: %w", err)
-		}
-	} else if err := os.Rename(src, dst); err != nil {
+	if err := archiveOrRemove(src, dst); err != nil {
 		logger.Error("Failed to archive notification %s: %v", id, err)
 		return fmt.Errorf("failed to archive notification: %w", err)
 	}
@@ -194,13 +185,7 @@ func ArchiveAllNotifications() error {
 		src := filepath.Join(notificationsDir, file.Name())
 		dst := filepath.Join(notificationsArchiveDir, file.Name())
 
-		// Keep the creation archive copy when it exists (see ArchiveNotification).
-		if _, err := os.Stat(dst); err == nil {
-			if err := os.Remove(src); err != nil {
-				logger.Warning("Failed to archive %s: %v", file.Name(), err)
-				continue
-			}
-		} else if err := os.Rename(src, dst); err != nil {
+		if err := archiveOrRemove(src, dst); err != nil {
 			logger.Warning("Failed to archive %s: %v", file.Name(), err)
 			continue
 		}
@@ -274,6 +259,18 @@ func writeFileAtomic(dir, name string, content []byte) error {
 		return err
 	}
 	return nil
+}
+
+// archiveOrRemove moves the unread file src into the archive as dst. Since the
+// issue #134 fix an archive copy (without link) is written at creation, so
+// archiving normally only needs to remove the unread file, like the stock
+// notify script's 'archive' verb; renaming over the copy would clobber it.
+// Files with no creation copy (legacy format) fall back to the rename.
+func archiveOrRemove(src, dst string) error {
+	if _, err := os.Stat(dst); err == nil {
+		return os.Remove(src)
+	}
+	return os.Rename(src, dst)
 }
 
 // validateFilename validates a filename to prevent path traversal attacks

--- a/daemon/services/controllers/notification.go
+++ b/daemon/services/controllers/notification.go
@@ -26,7 +26,13 @@ func init() {
 	notificationsDir, notificationsArchiveDir = collectors.ResolveNotificationDirs(constants.DynamixCfg)
 }
 
-// CreateNotification creates a new notification file
+// CreateNotification creates a new notification file in the same format as the
+// stock webGui notify script so both stock consumers (the legacy PHP parser and
+// unraid-api) can read it: an unquoted unix-epoch timestamp as the first line
+// (the stock parser treats the first line as the timestamp), stock field order
+// and value escaping, a safe_filename() style name, and an archive copy written
+// first. Files are written atomically so a failed write (e.g. ENOSPC) never
+// leaves a partial .notify file behind. See issue #134.
 func CreateNotification(title, subject, description, importance, link string) error {
 	// Validate importance
 	if importance != "alert" && importance != "warning" && importance != "info" {
@@ -34,16 +40,17 @@ func CreateNotification(title, subject, description, importance, link string) er
 	}
 
 	timestamp := time.Now()
-	sanitizedTitle := sanitizeFilename(title)
+	event := safeFilename(title)
+	if len(event) > 50 {
+		event = event[:50]
+	}
 
 	// Validate sanitized title to prevent path traversal
-	if err := validateFilename(sanitizedTitle); err != nil {
+	if err := validateFilename(event); err != nil {
 		return fmt.Errorf("invalid title: %w", err)
 	}
 
-	filename := fmt.Sprintf("%s-%s.notify",
-		timestamp.Format("20060102-150405"),
-		sanitizedTitle)
+	filename := fmt.Sprintf("%s_%d.notify", event, timestamp.Unix())
 
 	path := filepath.Join(notificationsDir, filename)
 
@@ -53,17 +60,20 @@ func CreateNotification(title, subject, description, importance, link string) er
 		return fmt.Errorf("invalid notification path: path escapes notifications directory")
 	}
 
-	content := fmt.Sprintf(`event="%s"
-subject="%s"
-description="%s"
-importance="%s"
-timestamp="%s"
-link="%s"`,
-		title, subject, description, importance,
-		timestamp.Format("2006-01-02 15:04:05"), link)
+	fields := fmt.Sprintf("timestamp=%d\nevent=%s\nsubject=%s\ndescription=%s\nimportance=%s\n",
+		timestamp.Unix(), iniQuote(title), iniQuote(subject), iniQuote(description), iniQuote(importance))
 
-	// #nosec G306 - Notification files need to be readable by Unraid web UI (0644)
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	// The stock script always writes the archive copy (without link) first and
+	// ignores its failure; only the unread copy decides the call's outcome.
+	// #nosec G301 - Unraid standard permissions (0755 for directories)
+	if err := os.MkdirAll(notificationsArchiveDir, 0755); err != nil {
+		logger.Warning("Failed to create archive directory for notification %s: %v", filename, err)
+	} else if err := writeFileAtomic(notificationsArchiveDir, filename, []byte(fields)); err != nil {
+		logger.Warning("Failed to write archive copy of notification %s: %v", filename, err)
+	}
+
+	unread := fields + fmt.Sprintf("link=%s\n", iniQuote(link))
+	if err := writeFileAtomic(notificationsDir, filename, []byte(unread)); err != nil {
 		logger.Error("Failed to create notification: %v", err)
 		return fmt.Errorf("failed to create notification: %w", err)
 	}
@@ -93,7 +103,16 @@ func ArchiveNotification(id string) error {
 		return fmt.Errorf("failed to create archive directory: %w", err)
 	}
 
-	if err := os.Rename(src, dst); err != nil {
+	// Since the issue #134 fix an archive copy (without link) is written at
+	// creation, so archiving normally only needs to remove the unread file,
+	// like the stock notify script's 'archive' verb; renaming over the copy
+	// would clobber it. Fall back to a rename for files with no archive copy.
+	if _, err := os.Stat(dst); err == nil {
+		if err := os.Remove(src); err != nil {
+			logger.Error("Failed to archive notification %s: %v", id, err)
+			return fmt.Errorf("failed to archive notification: %w", err)
+		}
+	} else if err := os.Rename(src, dst); err != nil {
 		logger.Error("Failed to archive notification %s: %v", id, err)
 		return fmt.Errorf("failed to archive notification: %w", err)
 	}
@@ -175,7 +194,13 @@ func ArchiveAllNotifications() error {
 		src := filepath.Join(notificationsDir, file.Name())
 		dst := filepath.Join(notificationsArchiveDir, file.Name())
 
-		if err := os.Rename(src, dst); err != nil {
+		// Keep the creation archive copy when it exists (see ArchiveNotification).
+		if _, err := os.Stat(dst); err == nil {
+			if err := os.Remove(src); err != nil {
+				logger.Warning("Failed to archive %s: %v", file.Name(), err)
+				continue
+			}
+		} else if err := os.Rename(src, dst); err != nil {
 			logger.Warning("Failed to archive %s: %v", file.Name(), err)
 			continue
 		}
@@ -186,22 +211,73 @@ func ArchiveAllNotifications() error {
 	return nil
 }
 
-// sanitizeFilename removes invalid characters from filename
-func sanitizeFilename(s string) string {
-	// Replace spaces with underscores
-	s = strings.ReplaceAll(s, " ", "_")
-	// Remove any character that's not alphanumeric, underscore, or hyphen
-	reg := regexp.MustCompile(`[^a-zA-Z0-9_-]`)
-	s = reg.ReplaceAllString(s, "")
-	// Limit length
-	if len(s) > 50 {
-		s = s[:50]
+var (
+	// notifySpecialChars removes the special characters the stock notify
+	// script's safe_filename() strips from notification file names.
+	notifySpecialChars = strings.NewReplacer(
+		"?", "", "[", "", "]", "", "/", "", "\\", "", "=", "", "<", "", ">", "",
+		":", "", ";", "", ",", "", "'", "", "\"", "", "&", "", "$", "", "#", "",
+		"*", "", "(", "", ")", "", "|", "", "~", "", "`", "", "!", "", "{", "", "}", "",
+	)
+	// notifyDisallowedChars matches everything else the stock safe_filename()
+	// removes: characters outside 0-9, a-z and the ASCII range 0x20-0x5F
+	// (written " -_" in the stock script; it already contains A-Z, which is
+	// why stock's /i flag is redundant). Deliberately no (?i): Go would apply
+	// Unicode case folding to the class, keeping U+212A/U+017F, which the
+	// stock byte-oriented pattern strips like any other non-ASCII input.
+	notifyDisallowedChars = regexp.MustCompile(`[^0-9a-z -_]`)
+	// notifyDashSpace converts hyphens and spaces to underscores like the
+	// stock safe_filename().
+	notifyDashSpace = strings.NewReplacer("-", "_", " ", "_")
+	// iniEscaper escapes backslashes and double quotes the same way the stock
+	// notify script's ini_encode_value() does (PHP strtr, single pass).
+	iniEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+)
+
+// safeFilename replicates the stock webGui notify script's safe_filename()
+// so agent notifications get the same file names the stock script produces.
+func safeFilename(s string) string {
+	s = strings.TrimSpace(notifySpecialChars.Replace(s))
+	s = notifyDisallowedChars.ReplaceAllString(s, "")
+	s = notifyDashSpace.Replace(s)
+	return strings.TrimSpace(s)
+}
+
+// iniQuote wraps a string value in double quotes with stock-compatible escaping.
+func iniQuote(v string) string {
+	return `"` + iniEscaper.Replace(v) + `"`
+}
+
+// writeFileAtomic writes content to dir/name via a temporary file and rename,
+// so a failed write (e.g. ENOSPC) never leaves a partial or empty .notify
+// file for the Unraid UI to flag as invalid. The temporary name does not end
+// in .notify, keeping it invisible to notification consumers.
+func writeFileAtomic(dir, name string, content []byte) error {
+	tmp, err := os.CreateTemp(dir, ".notify-tmp-*")
+	if err != nil {
+		return err
 	}
-	return s
+	tmpName := tmp.Name()
+	_, err = tmp.Write(content)
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err == nil {
+		// #nosec G302 - Notification files need to be readable by Unraid web UI (0644)
+		err = os.Chmod(tmpName, 0644)
+	}
+	if err == nil {
+		err = os.Rename(tmpName, filepath.Join(dir, name))
+	}
+	if err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
 }
 
 // validateFilename validates a filename to prevent path traversal attacks
-// This is used after sanitizeFilename to ensure the sanitized result is safe
+// This is used after safeFilename to ensure the sanitized result is safe
 func validateFilename(filename string) error {
 	if filename == "" {
 		return fmt.Errorf("filename cannot be empty")

--- a/daemon/services/controllers/notification.go
+++ b/daemon/services/controllers/notification.go
@@ -265,10 +265,15 @@ func writeFileAtomic(dir, name string, content []byte) error {
 // issue #134 fix an archive copy (without link) is written at creation, so
 // archiving normally only needs to remove the unread file, like the stock
 // notify script's 'archive' verb; renaming over the copy would clobber it.
-// Files with no creation copy (legacy format) fall back to the rename.
+// Files with no creation copy (legacy format) fall back to the rename. When
+// the check itself fails, the error is returned without touching either file:
+// renaming could clobber an existing copy and removing could delete the only
+// copy, and neither risk is worth taking blind.
 func archiveOrRemove(src, dst string) error {
 	if _, err := os.Stat(dst); err == nil {
 		return os.Remove(src)
+	} else if !os.IsNotExist(err) {
+		return err
 	}
 	return os.Rename(src, dst)
 }

--- a/daemon/services/controllers/notification.go
+++ b/daemon/services/controllers/notification.go
@@ -255,7 +255,9 @@ func writeFileAtomic(dir, name string, content []byte) error {
 		err = os.Rename(tmpName, filepath.Join(dir, name))
 	}
 	if err != nil {
-		_ = os.Remove(tmpName)
+		if rmErr := os.Remove(tmpName); rmErr != nil {
+			logger.Warning("Failed to clean up temp notification file %s: %v", tmpName, rmErr)
+		}
 		return err
 	}
 	return nil

--- a/daemon/services/controllers/notification_operations_test.go
+++ b/daemon/services/controllers/notification_operations_test.go
@@ -1,7 +1,9 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -616,6 +618,58 @@ func TestArchiveAllNotifications_KeepsCreationArchiveCopies(t *testing.T) {
 	}
 	if strings.Contains(string(content), "link=") {
 		t.Errorf("Archive copy was clobbered by the unread file (contains a link line):\n%s", content)
+	}
+}
+
+// TestArchiveOrRemove_AmbiguousCheckTouchesNothing verifies that when the
+// archive destination cannot be checked at all (stat fails with something
+// other than not-exists), the helper returns that error without attempting a
+// rename (which could clobber an existing archive copy) or a remove (which
+// could delete the only copy). The returned error's Op pins that the helper
+// stopped at the failed check rather than attempting a mutation.
+func TestArchiveOrRemove_AmbiguousCheckTouchesNothing(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("directory permissions are not enforced for root")
+	}
+
+	tmpDir := t.TempDir()
+	srcDir := filepath.Join(tmpDir, "unread")
+	dstDir := filepath.Join(tmpDir, "archive")
+	for _, d := range []string{srcDir, dstDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("Failed to create %s: %v", d, err)
+		}
+	}
+	src := filepath.Join(srcDir, "test.notify")
+	if err := os.WriteFile(src, []byte("data"), 0644); err != nil {
+		t.Fatalf("Failed to write source file: %v", err)
+	}
+	if err := os.Chmod(dstDir, 0000); err != nil {
+		t.Fatalf("Failed to make archive dir unreadable: %v", err)
+	}
+	defer os.Chmod(dstDir, 0755) //nolint:errcheck
+
+	err := archiveOrRemove(src, filepath.Join(dstDir, "test.notify"))
+	if err == nil {
+		t.Fatal("Expected an error when the destination cannot be checked")
+	}
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) || pathErr.Op != "stat" {
+		t.Errorf("Expected the stat error itself (no rename/remove attempted), got: %v", err)
+	}
+
+	if _, statErr := os.Stat(src); statErr != nil {
+		t.Errorf("Source file should be untouched after an ambiguous check: %v", statErr)
+	}
+	if err := os.Chmod(dstDir, 0755); err != nil {
+		t.Fatalf("Failed to restore archive dir permissions: %v", err)
+	}
+	entries, err := os.ReadDir(dstDir)
+	if err != nil {
+		t.Fatalf("Failed to read archive dir: %v", err)
+	}
+	for _, e := range entries {
+		t.Errorf("Archive dir should be untouched, found: %s", e.Name())
 	}
 }
 

--- a/daemon/services/controllers/notification_operations_test.go
+++ b/daemon/services/controllers/notification_operations_test.go
@@ -1,9 +1,14 @@
 package controllers
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 )
 
 // setupNotificationTestDirs creates temp directories and overrides the package-level vars.
@@ -240,7 +245,7 @@ func TestCreateNotification_ValidInput(t *testing.T) {
 	}
 
 	// Verify a file was created
-	files, _ := filepath.Glob(filepath.Join(notificationsDir, "*Test_Notification.notify"))
+	files, _ := filepath.Glob(filepath.Join(notificationsDir, "Test_Notification_*.notify"))
 	if len(files) == 0 {
 		t.Error("Expected notification file to be created")
 	}
@@ -279,13 +284,24 @@ func TestCreateNotification_SpecialCharactersInTitle(t *testing.T) {
 	defer cleanup()
 
 	tests := []struct {
-		name  string
-		title string
+		name    string
+		title   string
+		wantErr bool
 	}{
-		{"with spaces", "Test With Spaces"},
-		{"with special chars", "Test!@#$%^&*()"},
-		{"with slashes", "Test/With/Slashes"},
-		{"with dots", "Test...Dots"},
+		{"with spaces", "Test With Spaces", false},
+		{"with special chars", "Test!@#$%^&*()", false},
+		{"with slashes", "Test/With/Slashes", false},
+		// Dots survive the stock safe_filename() replica, so a title whose
+		// sanitized form contains ".." is rejected by the pre-existing
+		// path-traversal guard (stricter than stock, which would allow it).
+		{"with consecutive dots", "Test...Dots", true},
+		// safeFilename trims whitespace before converting spaces, like stock,
+		// so whitespace-only titles sanitize to empty and are rejected.
+		{"whitespace only", "   ", true},
+		// Characters stock's safe_filename() keeps (@ % ^ + .) survive the
+		// replica too, so punctuation-only titles are accepted like stock
+		// (the old sanitizer stripped them all and rejected the empty result).
+		{"punctuation only", "@%^+.", false},
 	}
 
 	for _, tt := range tests {
@@ -298,9 +314,329 @@ func TestCreateNotification_SpecialCharactersInTitle(t *testing.T) {
 				"",
 			)
 
-			if err != nil {
-				t.Logf("CreateNotification with '%s' failed: %v", tt.title, err)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("CreateNotification with %q should be rejected by the filename guard", tt.title)
+				}
+			} else if err != nil {
+				t.Errorf("CreateNotification with %q failed: %v", tt.title, err)
 			}
 		})
+	}
+}
+
+// TestCreateNotification_StockNotifyFormat verifies notification files match the
+// format written by Unraid's stock webGui notify script so the legacy PHP parser
+// and unraid-api can read them: an unquoted unix-epoch timestamp as the first
+// line, stock field order, escaped quotes/backslashes, a trailing newline, and
+// a safe_filename() style file name (issue #134).
+func TestCreateNotification_StockNotifyFormat(t *testing.T) {
+	cleanup := setupNotificationTestDirs(t)
+	defer cleanup()
+
+	before := time.Now().Unix()
+	err := CreateNotification(
+		"Management Agent Alert",
+		"Resolved: Agent data source degraded",
+		`Rule "cpu" resolved on \srv01`,
+		"warning",
+		"",
+	)
+	after := time.Now().Unix()
+
+	if err != nil {
+		t.Fatalf("CreateNotification failed: %v", err)
+	}
+
+	files, err := filepath.Glob(filepath.Join(notificationsDir, "*.notify"))
+	if err != nil {
+		t.Fatalf("Glob failed: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("Expected exactly one .notify file, got %d", len(files))
+	}
+
+	name := filepath.Base(files[0])
+	if !regexp.MustCompile(`^Management_Agent_Alert_\d+\.notify$`).MatchString(name) {
+		t.Errorf("Filename %q does not match the stock safe_filename() scheme", name)
+	}
+
+	content, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatalf("Failed to read notification file: %v", err)
+	}
+
+	info, err := os.Stat(files[0])
+	if err != nil {
+		t.Fatalf("Failed to stat notification file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Errorf("Notification file mode = %04o, want 0644 (readable by the Unraid web UI)", perm)
+	}
+
+	firstLine := strings.SplitN(string(content), "\n", 2)[0]
+	match := regexp.MustCompile(`^timestamp=(\d+)$`).FindStringSubmatch(firstLine)
+	if match == nil {
+		t.Fatalf("First line %q is not an unquoted unix-epoch timestamp", firstLine)
+	}
+	epoch, err := strconv.ParseInt(match[1], 10, 64)
+	if err != nil {
+		t.Fatalf("Failed to parse timestamp %q: %v", match[1], err)
+	}
+	if epoch < before || epoch > after {
+		t.Errorf("Timestamp %d outside test window [%d, %d]", epoch, before, after)
+	}
+
+	want := fmt.Sprintf("timestamp=%d\n"+
+		"event=\"Management Agent Alert\"\n"+
+		"subject=\"Resolved: Agent data source degraded\"\n"+
+		"description=\"Rule \\\"cpu\\\" resolved on \\\\srv01\"\n"+
+		"importance=\"warning\"\n"+
+		"link=\"\"\n", epoch)
+	if string(content) != want {
+		t.Errorf("Content mismatch:\ngot:\n%q\nwant:\n%q", string(content), want)
+	}
+}
+
+// TestCreateNotification_WritesArchiveCopy verifies a stock-style archive copy
+// (same fields, no link line) is written alongside the unread file, matching
+// the stock notify script behavior (issue #134).
+func TestCreateNotification_WritesArchiveCopy(t *testing.T) {
+	cleanup := setupNotificationTestDirs(t)
+	defer cleanup()
+
+	err := CreateNotification("Test Event", "Subject", "Description", "info", "http://example.com/x")
+	if err != nil {
+		t.Fatalf("CreateNotification failed: %v", err)
+	}
+
+	unreadFiles, err := filepath.Glob(filepath.Join(notificationsDir, "*.notify"))
+	if err != nil {
+		t.Fatalf("Glob failed: %v", err)
+	}
+	if len(unreadFiles) != 1 {
+		t.Fatalf("Expected one unread file, got %d", len(unreadFiles))
+	}
+	name := filepath.Base(unreadFiles[0])
+
+	archiveContent, err := os.ReadFile(filepath.Join(notificationsArchiveDir, name))
+	if err != nil {
+		t.Fatalf("Expected archive copy of %s: %v", name, err)
+	}
+
+	unreadContent, err := os.ReadFile(unreadFiles[0])
+	if err != nil {
+		t.Fatalf("Failed to read unread file: %v", err)
+	}
+	wantArchive := strings.Replace(string(unreadContent), "link=\"http://example.com/x\"\n", "", 1)
+	if string(archiveContent) != wantArchive {
+		t.Errorf("Archive copy mismatch:\ngot:\n%q\nwant:\n%q", string(archiveContent), wantArchive)
+	}
+}
+
+// TestCreateNotification_LongTitleCapped verifies the event part of the file
+// name keeps the pre-existing 50 character cap.
+func TestCreateNotification_LongTitleCapped(t *testing.T) {
+	cleanup := setupNotificationTestDirs(t)
+	defer cleanup()
+
+	longTitle := strings.Repeat("a", 80)
+	if err := CreateNotification(longTitle, "Subject", "Description", "info", ""); err != nil {
+		t.Fatalf("CreateNotification failed: %v", err)
+	}
+
+	files, err := filepath.Glob(filepath.Join(notificationsDir, "*.notify"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("Expected exactly one .notify file, got %d (err=%v)", len(files), err)
+	}
+
+	event := strings.SplitN(filepath.Base(files[0]), "_", 2)[0]
+	if len(event) != 50 {
+		t.Errorf("Expected event part capped at 50 characters, got %d (%q)", len(event), event)
+	}
+}
+
+// TestCreateNotification_NoFileLeftOnWriteFailure verifies a failed dispatch
+// leaves no partial, empty, or temporary file behind (issue #134).
+func TestCreateNotification_NoFileLeftOnWriteFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("directory permissions are not enforced for root")
+	}
+
+	cleanup := setupNotificationTestDirs(t)
+	defer cleanup()
+
+	for _, dir := range []string{notificationsDir, notificationsArchiveDir} {
+		if err := os.Chmod(dir, 0555); err != nil {
+			t.Fatalf("Failed to make %s read-only: %v", dir, err)
+		}
+		defer os.Chmod(dir, 0755) //nolint:errcheck
+	}
+
+	if err := CreateNotification("Test Event", "Subject", "Description", "info", ""); err == nil {
+		t.Fatal("Expected an error when the notifications directory is not writable")
+	}
+
+	entries, err := os.ReadDir(notificationsDir)
+	if err != nil {
+		t.Fatalf("Failed to read notifications dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() && e.Name() == filepath.Base(notificationsArchiveDir) {
+			continue // archive dir is nested inside the unread dir in tests
+		}
+		t.Errorf("Unexpected leftover entry after failed write: %s", e.Name())
+	}
+	archiveEntries, err := os.ReadDir(notificationsArchiveDir)
+	if err != nil {
+		t.Fatalf("Failed to read archive dir: %v", err)
+	}
+	for _, e := range archiveEntries {
+		t.Errorf("Unexpected leftover entry in archive after failed write: %s", e.Name())
+	}
+}
+
+// TestCreateNotification_ArchiveFailureDoesNotAbort verifies that a failed
+// archive copy is tolerated like the stock notify script tolerates it: the
+// unread notification is still delivered and no error is returned (issue #134).
+func TestCreateNotification_ArchiveFailureDoesNotAbort(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("directory permissions are not enforced for root")
+	}
+
+	cleanup := setupNotificationTestDirs(t)
+	defer cleanup()
+
+	if err := os.Chmod(notificationsArchiveDir, 0555); err != nil {
+		t.Fatalf("Failed to make archive dir read-only: %v", err)
+	}
+	defer os.Chmod(notificationsArchiveDir, 0755) //nolint:errcheck
+
+	if err := CreateNotification("Test Event", "Subject", "Description", "info", ""); err != nil {
+		t.Fatalf("CreateNotification should tolerate an archive write failure, got: %v", err)
+	}
+
+	unreadFiles, err := filepath.Glob(filepath.Join(notificationsDir, "*.notify"))
+	if err != nil || len(unreadFiles) != 1 {
+		t.Fatalf("Expected exactly one unread .notify file, got %d (err=%v)", len(unreadFiles), err)
+	}
+
+	archiveEntries, err := os.ReadDir(notificationsArchiveDir)
+	if err != nil {
+		t.Fatalf("Failed to read archive dir: %v", err)
+	}
+	for _, e := range archiveEntries {
+		t.Errorf("Unexpected entry in read-only archive dir: %s", e.Name())
+	}
+}
+
+// TestCreateNotification_UnreadFailureKeepsArchiveCopy pins the stock write
+// order: the archive copy is written first, so when only the unread write
+// fails the archive record is retained, exactly like the stock notify script
+// (issue #134).
+func TestCreateNotification_UnreadFailureKeepsArchiveCopy(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("directory permissions are not enforced for root")
+	}
+
+	cleanup := setupNotificationTestDirs(t)
+	defer cleanup()
+
+	if err := os.Chmod(notificationsDir, 0555); err != nil {
+		t.Fatalf("Failed to make notifications dir read-only: %v", err)
+	}
+	defer os.Chmod(notificationsDir, 0755) //nolint:errcheck
+
+	if err := CreateNotification("Test Event", "Subject", "Description", "info", ""); err == nil {
+		t.Fatal("Expected an error when the unread directory is not writable")
+	}
+
+	archiveFiles, err := filepath.Glob(filepath.Join(notificationsArchiveDir, "Test_Event_*.notify"))
+	if err != nil || len(archiveFiles) != 1 {
+		t.Fatalf("Expected the archive copy to be retained after unread write failure, got %d (err=%v)", len(archiveFiles), err)
+	}
+}
+
+// TestArchiveNotification_KeepsCreationArchiveCopy verifies that archiving via
+// the agent preserves the archive copy written at creation (which has no link
+// line), like the stock notify script's 'archive' verb, which only deletes the
+// unread file. Renaming the unread file over it would clobber that copy
+// (issue #134).
+func TestArchiveNotification_KeepsCreationArchiveCopy(t *testing.T) {
+	cleanup := setupNotificationTestDirs(t)
+	defer cleanup()
+
+	if err := CreateNotification("Test Event", "Subject", "Description", "info", "http://example.com/x"); err != nil {
+		t.Fatalf("CreateNotification failed: %v", err)
+	}
+	unreadFiles, err := filepath.Glob(filepath.Join(notificationsDir, "*.notify"))
+	if err != nil || len(unreadFiles) != 1 {
+		t.Fatalf("Expected one unread file, got %d (err=%v)", len(unreadFiles), err)
+	}
+	name := filepath.Base(unreadFiles[0])
+
+	if err := ArchiveNotification(name); err != nil {
+		t.Fatalf("ArchiveNotification failed: %v", err)
+	}
+
+	if _, err := os.Stat(unreadFiles[0]); !os.IsNotExist(err) {
+		t.Errorf("Expected unread file to be removed, stat err: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(notificationsArchiveDir, name))
+	if err != nil {
+		t.Fatalf("Expected the creation archive copy to remain: %v", err)
+	}
+	if strings.Contains(string(content), "link=") {
+		t.Errorf("Archive copy was clobbered by the unread file (contains a link line):\n%s", content)
+	}
+}
+
+// TestArchiveAllNotifications_KeepsCreationArchiveCopies verifies the bulk
+// archive operation preserves creation archive copies the same way (issue #134).
+func TestArchiveAllNotifications_KeepsCreationArchiveCopies(t *testing.T) {
+	cleanup := setupNotificationTestDirs(t)
+	defer cleanup()
+
+	if err := CreateNotification("Bulk Event", "Subject", "Description", "info", "http://example.com/y"); err != nil {
+		t.Fatalf("CreateNotification failed: %v", err)
+	}
+	unreadFiles, err := filepath.Glob(filepath.Join(notificationsDir, "*.notify"))
+	if err != nil || len(unreadFiles) != 1 {
+		t.Fatalf("Expected one unread file, got %d (err=%v)", len(unreadFiles), err)
+	}
+	name := filepath.Base(unreadFiles[0])
+
+	if err := ArchiveAllNotifications(); err != nil {
+		t.Fatalf("ArchiveAllNotifications failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(notificationsArchiveDir, name))
+	if err != nil {
+		t.Fatalf("Expected the creation archive copy to remain: %v", err)
+	}
+	if strings.Contains(string(content), "link=") {
+		t.Errorf("Archive copy was clobbered by the unread file (contains a link line):\n%s", content)
+	}
+}
+
+// TestWriteFileAtomic_CleansUpTempOnFailure verifies the atomic writer removes
+// its temporary file when the write cannot complete, so a failure mid-dispatch
+// (e.g. ENOSPC) never leaves anything behind in the directory (issue #134).
+func TestWriteFileAtomic_CleansUpTempOnFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Renaming onto a path inside a nonexistent subdirectory must fail after
+	// the temporary file has already been created and written.
+	err := writeFileAtomic(tmpDir, filepath.Join("missing-subdir", "test.notify"), []byte("data"))
+	if err == nil {
+		t.Fatal("Expected an error when the rename target cannot be created")
+	}
+
+	entries, readErr := os.ReadDir(tmpDir)
+	if readErr != nil {
+		t.Fatalf("Failed to read temp dir: %v", readErr)
+	}
+	for _, e := range entries {
+		t.Errorf("Unexpected leftover entry after failed atomic write: %s", e.Name())
 	}
 }

--- a/daemon/services/controllers/notification_security_test.go
+++ b/daemon/services/controllers/notification_security_test.go
@@ -167,8 +167,9 @@ func TestDeleteNotificationSecurity(t *testing.T) {
 	}
 }
 
-// TestSanitizeFilename tests the sanitizeFilename function
-func TestSanitizeFilename(t *testing.T) {
+// TestSafeFilename tests the safeFilename function, which replicates the
+// stock webGui notify script's safe_filename() (issue #134)
+func TestSafeFilename(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -187,12 +188,12 @@ func TestSanitizeFilename(t *testing.T) {
 		{
 			name:     "filename with special characters",
 			input:    "test@file#name!",
-			expected: "testfilename",
+			expected: "test@filename",
 		},
 		{
 			name:     "filename with dots",
 			input:    "test.file.name",
-			expected: "testfilename",
+			expected: "test.file.name",
 		},
 		{
 			name:     "filename with path separators",
@@ -202,12 +203,12 @@ func TestSanitizeFilename(t *testing.T) {
 		{
 			name:     "filename with parent dir refs",
 			input:    "../../../etc/passwd",
-			expected: "etcpasswd",
+			expected: "......etcpasswd",
 		},
 		{
-			name:     "filename with mixed chars",
+			name:     "hyphens become underscores like stock",
 			input:    "test-file_123",
-			expected: "test-file_123",
+			expected: "test_file_123",
 		},
 		{
 			name:     "empty string",
@@ -215,22 +216,24 @@ func TestSanitizeFilename(t *testing.T) {
 			expected: "",
 		},
 		{
-			name:     "very long filename",
-			input:    "this_is_a_very_long_filename_that_exceeds_the_fifty_character_limit_for_filenames",
-			expected: "this_is_a_very_long_filename_that_exceeds_the_fift",
-		},
-		{
 			name:     "unicode characters",
 			input:    "test_éàü_file",
+			expected: "test__file",
+		},
+		{
+			// U+212A (KELVIN SIGN) and U+017F (LONG S) case-fold to k/s, so a
+			// (?i) class would keep them; stock's byte-oriented PCRE strips them.
+			name:     "unicode case-fold characters",
+			input:    "test_\u212A\u017F_file",
 			expected: "test__file",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sanitizeFilename(tt.input)
+			result := safeFilename(tt.input)
 			if result != tt.expected {
-				t.Errorf("sanitizeFilename(%q) = %q, want %q", tt.input, result, tt.expected)
+				t.Errorf("safeFilename(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
 	}
@@ -321,6 +324,11 @@ func TestCreateNotificationValidation(t *testing.T) {
 	})
 
 	t.Run("valid importance levels", func(t *testing.T) {
+		// Redirect the package-level dirs: without this, a root run would
+		// create real files under /boot via the archive-first write path.
+		cleanup := setupNotificationTestDirs(t)
+		defer cleanup()
+
 		levels := []string{"alert", "warning", "info"}
 		for _, level := range levels {
 			t.Run(level, func(t *testing.T) {


### PR DESCRIPTION
Hiya! 👋 Thanks for taking a look at this. I hit the edge case I'd reported in #134 and since
I'd done some debugging, the code wasn't much of an extra step.

## Description

Notification files written by the agent crash Unraid's stock PHP notification parser and, under
ENOSPC, leave 0-byte `.notify` husks behind (#134). This PR makes `CreateNotification` write a
stock-compatible file format matching the webGui `notify` script's output, and makes every write
atomic.

The stock `notify get` parser (used by the webGui notification poll) blindly runs
`date($fmt, $val)` on the **first** `key=value` line of each file, with no key check. Agent files
started with `event="..."` (and carried a quoted datetime `timestamp="..."` further down), so
every poll threw a PHP `TypeError` fatal, flooding `/var/log/phplog` (~189k fatals / 75MB on my
system). Separately, `os.WriteFile` under ENOSPC creates the file before failing the
write, leaving 0-byte husks the UI flags as "invalid notification" with a fresh timestamp on
every page load.

All notification producers go through `CreateNotification`, so the alerting `unraid` channel,
`POST /api/v1/notifications`, watchdog, and plugin-update notices are all fixed at once.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Hardware compatibility fix
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [x] Test additions/improvements

Marked non-breaking as the behavioral notes under Breaking Changes affect only edge-case titles
from arbitrary API callers (plus id/timestamp shape); every built-in producer and stock consumer
is unaffected. Happy to reclassify if you read the template's definition more strictly.

## Related Issues

Fixes #134

## Hardware Configuration (if applicable)

Not hardware-related (notification/alerting pipeline).

- **Unraid Version:** reproduced on 7.3.1, plugin 2026.06.07, x86_64

## Changes Made

All format details were verified line-by-line against the stock script's `build_ini_string()`,
`ini_decode_value()`, and `safe_filename()` in unraid/webgui.

- **Stock-compatible file body** (`daemon/services/controllers/notification.go`): unquoted
  unix-epoch `timestamp=` as the first line, stock field order (`timestamp`, `event`, `subject`,
  `description`, `importance`, then `link` in the unread copy only), backslash/double-quote
  escaping identical to `ini_encode_value()`, trailing newline.
- **Stock-style file names**: Go replica of `safe_filename()` applied to the title +
  `_<epoch>.notify` (e.g. `Management_Agent_Alert_1783092000.notify`), replacing the previous
  `20060102-150405-Title.notify` scheme. The pre-existing 50-char title cap and path-traversal
  guard are retained. The replica deliberately omits Go's `(?i)` flag: RE2 case-folds character
  classes before negation, which would keep U+212A/U+017F that stock's byte-oriented pattern
  strips (and A-Z is already inside the pattern's 0x20-0x5F range).
- **Archive copy written first**, best-effort, like stock (stock ignores archive write errors;
  the unread copy alone decides the call's outcome). Dismissed notifications now keep their
  archive history, matching stock behaviour. Archiving via the agent's API accordingly now
  removes the unread file and keeps that creation-time copy, like the stock `archive` verb (a
  rename would clobber it); files without a creation copy still fall back to the old rename, and
  if the existence check itself fails the error is surfaced and neither file is touched.
- **Atomic writes**: temp file (`.notify-tmp-*`, never matches `*.notify` globs) + `rename()`,
  with the temp removed on any failure — a failed dispatch can no longer leave a partial or
  empty file. This is deliberately stronger than stock, which also husks under ENOSPC.
- **Collector parser** (`daemon/services/collectors/notification.go`) now reads the stock format
  it writes (unquoted epoch, escaped values via an `ini_decode_value()` equivalent) while still
  parsing the legacy quoted-datetime format of files created by older agent versions. This also
  fixes timestamps for notifications created by the stock script itself, which previously fell
  back to file mtime. Parsed epochs are bounded to years [1970, 9999] and timestamps are stored
  as UTC, so every parse path renders the same Z-suffixed RFC3339 form regardless of host
  timezone and the cap alone bounds the year `MarshalJSON` validates. Out-of-range values fall
  back to file mtime instead of producing a `time.Time` that fails JSON marshaling and would
  otherwise break encoding of the whole notification list (REST/WS/MQTT).
- **CHANGELOG.md**: entry added under `## [Unreleased]` describing the fix.
- **Tests**: new golden-format, atomicity, archive-semantics, and parser tests; existing tests
  updated where they pinned the old format (details below).

## Testing Performed

- [x] Unit tests pass (`make test` — full suite; see sandbox note under Test Results)
- [x] Added new tests for new functionality
- [ ] Tested on actual Unraid system (my affected system from #134 is available for
      before/after validation prior to merge)
- [x] Verified affected API endpoints work correctly (unit level; no API signatures changed)
- [ ] Tested WebSocket events (n/a — no event shape changes)
- [ ] Tested with debug logging enabled
- [x] Regression testing (full suite, plus `go test -race` on the touched packages)

### Test Results

New/updated tests (table-driven where the repo convention applies):

- `TestCreateNotification_StockNotifyFormat` — byte-exact golden check of the unread file
  (epoch-first unquoted timestamp, stock field order, `\"`/`\\` escaping, trailing newline),
  `safe_filename()`-style naming, and the 0644 mode the web UI needs.
- `TestCreateNotification_WritesArchiveCopy` — archive copy present, identical minus the `link`
  line.
- `TestCreateNotification_UnreadFailureKeepsArchiveCopy` — pins the stock write order: archive
  first, retained when only the unread write fails.
- `TestCreateNotification_LongTitleCapped` — 50-char title cap retained.
- `TestCreateNotification_NoFileLeftOnWriteFailure` — failed dispatch leaves no file, no husk,
  no temp (skips as root, where directory permissions aren't enforced).
- `TestCreateNotification_ArchiveFailureDoesNotAbort` — archive write failure is tolerated like
  stock; unread copy still delivered.
- `TestArchiveNotification_KeepsCreationArchiveCopy` and
  `TestArchiveAllNotifications_KeepsCreationArchiveCopies` — archiving removes the unread file
  and preserves the creation-time archive copy instead of clobbering it.
- `TestArchiveOrRemove_AmbiguousCheckTouchesNothing` — a failed existence check on the archive
  destination returns the error without attempting a rename or remove; both files untouched.
- `TestWriteFileAtomic_CleansUpTempOnFailure` — atomic writer removes its temp on failure.
- `TestParseNotificationFile_StockFormat` — collector parses unquoted epoch, legacy quoted
  datetime, escaped values, falls back to the file's actual mtime for out-of-range epochs, pins
  the Z-suffixed UTC rendering with a host-independent literal, and stays JSON-marshalable at
  the epoch cap in any timezone (verified manually under `TZ=Asia/Tokyo` and
  `TZ=Pacific/Kiritimati`).
- `TestSafeFilename` — updated to the stock `safe_filename()` semantics, including the
  case-folding pitfall rows.
- `TestCreateNotification_SpecialCharactersInTitle` — tightened: titles whose sanitized form
  contains `..` (e.g. `Test...Dots`) are now explicitly expected to be rejected (see Breaking
  Changes).
- Test hygiene: the pre-existing importance-validation subtest and two api-package notification
  handler tests now redirect to temp dirs / skip as root — with the new archive-first write they
  would otherwise create real files under `/boot` when the suite runs as root on a dev host.

Every guarded behaviour was mutation- or red-tested: re-introducing the original bug
(event-first/quoted timestamp), removing the temp cleanup, disabling epoch parsing, and aborting
on archive failure each made exactly the guarding test fail; the archive-clobber,
timezone-boundary, and ambiguous-check tests were written failing against the defect first.

`gofmt` clean, `go vet` clean, `golangci-lint run --new-from-rev` reports 0 new issues,
`go test -race` clean on the touched packages (controllers, collectors, api).

Full-suite note: development ran in a network-isolated sandbox where two pre-existing MQTT tests
(`TestTestConnection`, `TestPackageLevelTestConnection_InvalidBroker`) fail because instant DNS
failure yields 0ms latency; they fail identically on a clean checkout in that sandbox and pass
in normal environments.

## **API Endpoints Tested:**

Unit level (handler and controller tests; no signatures changed):

- `POST /api/v1/notifications` — creation via handler tests, including default-importance path.
- `GET /api/v1/notifications` — parse/marshal path via collector tests (stock, legacy, and
  boundary-epoch inputs).
- `POST /api/v1/notifications/{id}/archive`, `.../unarchive`, `DELETE /api/v1/notifications/{id}`
  — controller tests, including the new keep-creation-archive-copy semantics.

- **Test Output/Results:**

```
ok  github.com/ruaan-deysel/unraid-management-agent/daemon/services/controllers
ok  github.com/ruaan-deysel/unraid-management-agent/daemon/services/collectors
ok  github.com/ruaan-deysel/unraid-management-agent/daemon/services/api
(full `go test ./...` green apart from the two documented sandbox-environment MQTT
failures above, which also fail on a clean checkout in that sandbox; -race green on
the three packages listed)
```

**Log Output (if relevant):**

```
(n/a — see issue #134 for the phplog fatals and agent log excerpts this fixes)
```

## Documentation

- [x] Code comments added/updated
- [ ] README.md updated (if needed) — not needed
- [ ] CLAUDE.md updated (if architecture changed) — no architecture change
- [ ] CONTRIBUTING.md updated (if contribution process changed) — n/a
- [ ] API documentation updated (if API changed) — no API shape change
- [ ] No documentation needed
- [x] CHANGELOG.md updated (entry under `## [Unreleased]`)

## Breaking Changes

## **Breaking Changes:**

None for stock consumers. Four behavioral notes for consumers of the agent's own API:

1. Notification `id` values (the filename, as returned by `/api/v1/notifications` and used by
   archive/delete operations) change shape for newly created notifications:
   `20260703-152000-Management_Agent_Alert.notify` → `Management_Agent_Alert_1783092000.notify`.
   Existing files keep working; IDs remain opaque `.notify` filenames.
2. API `timestamp` fields change in two ways: stock-created notifications now use the epoch
   stored in the file instead of the near-identical mtime fallback, and newly created agent
   notifications now carry the correct instant (the old code wrote zoneless local wall time that
   the collector parsed as UTC, so on non-UTC hosts their API timestamps previously ran ahead or
   behind by the host's UTC offset). All timestamps are now rendered uniformly in UTC
   (Z-suffixed RFC3339) regardless of host timezone. Legacy-format agent files' timestamps parse exactly as
   before; quoted legacy values containing literal backslashes are now decoded with stock
   `stripslashes` semantics (the old reader left them intact), a niche case since the old
   writer never escaped values.
3. Titles whose sanitized form contains `..` (e.g. `Test...Dots`) are now rejected with an
   error: dots survive the stock `safe_filename()` replica (the old sanitizer stripped them),
   and the retained path-traversal guard rejects `..` anywhere in a filename — stricter than
   stock, which would create such files. All built-in producers use dot-free titles; only
   arbitrary API callers can hit this, and the rejection is now pinned by a test.
4. Two more edge-title outcomes change for arbitrary API callers, both pinned by tests: titles
   containing none of `[a-zA-Z0-9_-]` but only characters stock keeps (e.g. `@%^+.`) were
   previously rejected as empty-after-sanitize and now create notifications like stock would
   (a title starting with `.` yields a hidden leading-dot filename, which the agent's API lists
   but stock's `*.notify` glob skips); conversely, whitespace-only titles were previously
   accepted as underscore filenames and are now rejected as empty, because trimming happens
   before space conversion, matching stock's trim placement.

## **Migration Guide:**

None required. API consumers that treat notification IDs as opaque `.notify` filenames are
unaffected.

## Screenshots/Logs

N/A — UI symptoms, phplog excerpts, and agent log excerpts are documented in issue #134.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (`golangci-lint --new-from-rev`: 0 issues)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (n/a — none)
- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] No sensitive information (API keys, passwords, personal data) is included

## Hardware Compatibility Notes

N/A — not a hardware compatibility fix.

## Additional Notes

Intentional non-goals, kept out to stay minimal (happy to follow up on any):

- Stock's per-importance entity routing (browser/email/agents gating from `dynamix.cfg`) and its
  same-name dedup skip are not replicated; the agent still always writes the unread copy. As a
  consequence, two notifications for the same event within the same second overwrite each other
  (last write wins, atomically) where stock would skip the second entirely.
- `clean_subject()` HTML-entity stripping is not replicated (agent subjects never contain
  entities).
- Extra fsnotify `collect()` cycles from temp-file create events are accepted; temp names never
  match `*.notify`, so nothing ever parses them.

Related observations, not addressed here:

- Pre-existing: the alert dispatcher maps info-severity to importance `"normal"`
  (`daemon/services/alerting/dispatcher.go`), which `CreateNotification` rejects (it accepts
  `alert|warning|info`), so info-severity alerts to the `unraid` channel currently fail. Note
  also stock's vocabulary is `normal|warning|alert` — `"info"` is agent-only. Left untouched to
  keep this PR scoped to #134; can file separately.
- Pre-existing: `TestSanitizeFilenameCases` in `notification_additional_test.go` tests a local
  test-only helper (`sanitizeTestFilename`) that documents the old sanitization semantics; left
  untouched per "don't delete unrelated code", flagging it for a future cleanup.
- The issue's side observation about resolve-event severity/cooldown is not addressed here
  (explicitly optional in the issue).

---

Thanks a lot for taking the time to review this (and for the plugin itself!). Happy to adjust
anything, split it up further or anything else I can do to help. Cheers!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification `.notify` output is now stock-compatible INI-style `key=value`, with safer filename derivation (`event_<unix_epoch>.notify`) and improved archiving behaviour.
* **Bug Fixes**
  * Fixed crashes when parsing agent-created notifications by supporting both legacy and stock notification formats.
  * Improved `timestamp` handling (epoch bounds, consistent UTC/RFC3339 formatting, and safe fallbacks).
  * Atomic, two-phase writes prevent empty/partial files; archiving no longer overwrites existing archive copies.
* **Tests**
  * Added stock-format parsing/formatting tests, expanded atomic/archive/read-order assertions, and refined filename safety coverage (including root-run skips).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->