### PR TITLE
fix(controllers): accept the stock "normal" importance so info-severity alerts reach the unraid channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Info-severity alerts now reach the `unraid` channel** (#144) — the alert dispatcher
+  sends importance `normal` for info-severity events, which `CreateNotification` rejected, so
+  those dispatches always failed with `invalid importance level: normal` before any file was
+  written. `CreateNotification` now accepts `normal` — the stock notify script's own level for
+  informational notifications — alongside `alert`, `warning`, and the agent's own `info`.
+
 ## [2026.07.00] - 2026-07-10
 
 ### Fixed

--- a/daemon/lib/validation.go
+++ b/daemon/lib/validation.go
@@ -613,3 +613,16 @@ func ValidateRemoteShareSource(source string) error {
 	}
 	return nil
 }
+
+// ValidateNotificationImportance validates an Unraid notification importance
+// level. "normal" is the stock notify script's own level for informational
+// notifications (and what the alert dispatcher sends for info-severity events);
+// "info" is the agent's own equivalent, and remains the REST default.
+func ValidateNotificationImportance(importance string) error {
+	switch importance {
+	case "alert", "warning", "normal", "info":
+		return nil
+	default:
+		return fmt.Errorf("invalid importance level: %s (must be alert, warning, normal, or info)", importance)
+	}
+}

--- a/daemon/lib/validation_test.go
+++ b/daemon/lib/validation_test.go
@@ -892,3 +892,33 @@ func TestValidateBindAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNotificationImportance(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "alert", input: "alert"},
+		{name: "warning", input: "warning"},
+		{name: "normal (stock informational level)", input: "normal"},
+		{name: "info (agent equivalent)", input: "info"},
+		{name: "unknown level", input: "debug", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+		{name: "wrong case", input: "Alert", wantErr: true},
+		{name: "not trimmed", input: " normal ", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNotificationImportance(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateNotificationImportance(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "invalid importance level") {
+				t.Errorf("ValidateNotificationImportance(%q) error = %q, want it to contain %q", tt.input, err, "invalid importance level")
+			}
+		})
+	}
+}

--- a/daemon/services/controllers/notification.go
+++ b/daemon/services/controllers/notification.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ruaan-deysel/unraid-management-agent/daemon/constants"
+	"github.com/ruaan-deysel/unraid-management-agent/daemon/lib"
 	"github.com/ruaan-deysel/unraid-management-agent/daemon/logger"
 	"github.com/ruaan-deysel/unraid-management-agent/daemon/services/collectors"
 )
@@ -35,12 +36,8 @@ func init() {
 // first. Files are written atomically so a failed write (e.g. ENOSPC) never
 // leaves a partial .notify file behind. See issue #134.
 func CreateNotification(title, subject, description, importance, link string) error {
-	// Validate importance. "normal" is the stock notify script's own level for
-	// informational notifications, and what the alert dispatcher sends for
-	// info-severity events; "info" remains the REST default and is used by
-	// existing in-repo callers.
-	if importance != "alert" && importance != "warning" && importance != "normal" && importance != "info" {
-		return fmt.Errorf("invalid importance level: %s (must be alert, warning, normal, or info)", importance)
+	if err := lib.ValidateNotificationImportance(importance); err != nil {
+		return err
 	}
 
 	timestamp := time.Now()

--- a/daemon/services/controllers/notification.go
+++ b/daemon/services/controllers/notification.go
@@ -35,9 +35,12 @@ func init() {
 // first. Files are written atomically so a failed write (e.g. ENOSPC) never
 // leaves a partial .notify file behind. See issue #134.
 func CreateNotification(title, subject, description, importance, link string) error {
-	// Validate importance
-	if importance != "alert" && importance != "warning" && importance != "info" {
-		return fmt.Errorf("invalid importance level: %s (must be alert, warning, or info)", importance)
+	// Validate importance. "normal" is the stock notify script's own level for
+	// informational notifications, and what the alert dispatcher sends for
+	// info-severity events; "info" remains the REST default and is used by
+	// existing in-repo callers.
+	if importance != "alert" && importance != "warning" && importance != "normal" && importance != "info" {
+		return fmt.Errorf("invalid importance level: %s (must be alert, warning, normal, or info)", importance)
 	}
 
 	timestamp := time.Now()

--- a/daemon/services/controllers/notification_operations_test.go
+++ b/daemon/services/controllers/notification_operations_test.go
@@ -270,8 +270,11 @@ func TestCreateNotification_InvalidImportance(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error for invalid importance level")
 	}
-	if !strings.Contains(err.Error(), "invalid importance level") {
-		t.Errorf("Expected an importance validation error, got: %v", err)
+	// Assert the whole message: it advertises the accepted levels, so this
+	// pins that list as part of the error contract.
+	const want = "invalid importance level: invalid (must be alert, warning, normal, or info)"
+	if got := err.Error(); got != want {
+		t.Errorf("CreateNotification() error = %q, want %q", got, want)
 	}
 	// Validation rejects before anything is written.
 	for _, dir := range []string{notificationsDir, notificationsArchiveDir} {

--- a/daemon/services/controllers/notification_operations_test.go
+++ b/daemon/services/controllers/notification_operations_test.go
@@ -254,6 +254,11 @@ func TestCreateNotification_ValidInput(t *testing.T) {
 }
 
 func TestCreateNotification_InvalidImportance(t *testing.T) {
+	// Redirect the package-level dirs so the assertions below distinguish a
+	// validation rejection from an incidental write failure.
+	cleanup := setupNotificationTestDirs(t)
+	defer cleanup()
+
 	err := CreateNotification(
 		"Test",
 		"Subject",
@@ -263,7 +268,20 @@ func TestCreateNotification_InvalidImportance(t *testing.T) {
 	)
 
 	if err == nil {
-		t.Error("Expected error for invalid importance level")
+		t.Fatal("Expected error for invalid importance level")
+	}
+	if !strings.Contains(err.Error(), "invalid importance level") {
+		t.Errorf("Expected an importance validation error, got: %v", err)
+	}
+	// Validation rejects before anything is written.
+	for _, dir := range []string{notificationsDir, notificationsArchiveDir} {
+		files, err := filepath.Glob(filepath.Join(dir, "*.notify"))
+		if err != nil {
+			t.Fatalf("Failed to glob %s: %v", dir, err)
+		}
+		if len(files) != 0 {
+			t.Errorf("Expected no .notify files in %s, got %d", dir, len(files))
+		}
 	}
 }
 
@@ -322,6 +340,42 @@ func TestCreateNotification_SpecialCharactersInTitle(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Errorf("CreateNotification with %q failed: %v", tt.title, err)
+			}
+		})
+	}
+}
+
+// TestCreateNotification_InformationalImportance pins both informational
+// importance levels: "normal", the stock notify script's own level and what the
+// alert dispatcher sends for info-severity events, and "info", which existing
+// API callers still send. Each is written verbatim to the unread and archive
+// copies, so neither is silently rewritten as the other.
+func TestCreateNotification_InformationalImportance(t *testing.T) {
+	for _, importance := range []string{"normal", "info"} {
+		t.Run(importance, func(t *testing.T) {
+			cleanup := setupNotificationTestDirs(t)
+			defer cleanup()
+
+			if err := CreateNotification("Test Event", "Subject", "Description", importance, ""); err != nil {
+				t.Fatalf("CreateNotification should accept importance %q: %v", importance, err)
+			}
+
+			want := fmt.Sprintf("importance=%q\n", importance)
+			for _, dir := range []string{notificationsDir, notificationsArchiveDir} {
+				files, err := filepath.Glob(filepath.Join(dir, "*.notify"))
+				if err != nil {
+					t.Fatalf("Failed to glob %s: %v", dir, err)
+				}
+				if len(files) != 1 {
+					t.Fatalf("Expected exactly one .notify file in %s, got %d", dir, len(files))
+				}
+				content, err := os.ReadFile(files[0])
+				if err != nil {
+					t.Fatalf("Failed to read notification file: %v", err)
+				}
+				if !strings.Contains(string(content), want) {
+					t.Errorf("Expected %s in %s, got:\n%s", want, dir, content)
+				}
 			}
 		})
 	}

--- a/daemon/services/controllers/notification_security_test.go
+++ b/daemon/services/controllers/notification_security_test.go
@@ -329,13 +329,11 @@ func TestCreateNotificationValidation(t *testing.T) {
 		cleanup := setupNotificationTestDirs(t)
 		defer cleanup()
 
-		levels := []string{"alert", "warning", "info"}
+		levels := []string{"alert", "warning", "normal", "info"}
 		for _, level := range levels {
 			t.Run(level, func(t *testing.T) {
-				err := CreateNotification("test-"+level, "subject", "desc", level, "")
-				// Will fail without notifications directory, but validates importance first
-				if err != nil && err.Error() == "invalid importance level: "+level {
-					t.Errorf("Should accept importance level %q", level)
+				if err := CreateNotification("test-"+level, "subject", "desc", level, ""); err != nil {
+					t.Errorf("Should accept importance level %q: %v", level, err)
 				}
 			})
 		}


### PR DESCRIPTION
## Description

Hiya, this is the follow-up to the observation I left on #135, now filed as #144.

Alert rules with `info` severity that dispatch to the `unraid` channel always fail before a
notification file is written: the dispatcher (`daemon/services/alerting/dispatcher.go`,
`sendToUnraid`) sends importance `normal` for those events, which `CreateNotification`
rejected (`invalid importance level: normal`).

This accepts `normal` — the stock notify script's own level for informational notifications
(`notify -i "normal|warning|alert"`) — alongside `alert`, `warning`, and `info`, which stays
accepted as the REST default and for the in-repo callers that already use it. The value is
written verbatim, and the collector already buckets `normal` together with `info` when
counting, so no in-repo reader changes are needed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Hardware compatibility fix
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [x] Test additions/improvements

## Related Issues

Fixes #144

## Hardware Configuration (if applicable)

N/A — code-level bug in the alerting/notification pipeline.

## Changes Made

- `daemon/lib/validation.go` — new `ValidateNotificationImportance` accepting `alert`,
  `warning`, `normal`, and `info`, so the allow-list lives with the other validators as the
  controller guidelines ask. The error string is unchanged from the inline version.
- `daemon/lib/validation_test.go` — table-driven coverage for the new validator.
- `daemon/services/controllers/notification.go` — accept `normal`, and call the shared
  validator instead of an inline allow-list.
- `daemon/services/controllers/notification_operations_test.go` — new
  `TestCreateNotification_InformationalImportance` pins that both `normal` and `info` are
  accepted and written verbatim to the unread and archive copies, so neither is silently
  rewritten as the other. `TestCreateNotification_InvalidImportance` now redirects the
  package-level directories, matches on the validation error, and asserts no `.notify` file is
  left behind, so it can tell a rejection apart from an incidental write failure.
- `daemon/services/controllers/notification_security_test.go` — `normal` added to the
  valid-importance table, and its assertion now actually fails on a rejected level (the old
  comparison could never match the real error string).
- `CHANGELOG.md` — entry under `## [Unreleased]`.

## Testing Performed

- [ ] Unit tests pass — see Test Results: the controllers package is green, but the full-suite
      command exits non-zero on two MQTT tests that fail identically on `origin/main`
- [x] Added new tests for new functionality
- [ ] Tested on actual Unraid system
- [ ] Verified affected API endpoints work correctly (controller-level only — no endpoint
      signature or schema annotation changed)
- [ ] Tested WebSocket events (n/a)
- [ ] Tested with debug logging enabled
- [x] Regression testing (full suite run and compared against `origin/main`)

### Test Results

`go test ./daemon/services/controllers/` is green. The new test was written first and failed
with the error `CreateNotification` returns on `origin/main`
(`invalid importance level: normal (must be alert, warning, or info)`), then passed after the
fix. I also mutation-checked it: reverting the allowlist, removing the validation, and
silently rewriting `info` as `normal` on write each make the relevant test fail. After moving
the check into `daemon/lib`, dropping `normal` from the shared validator still fails the
controller tests, so the indirection did not cost any coverage.

`go test ./...` exits non-zero for me, but on two MQTT tests unrelated to this change:

```
--- FAIL: TestPackageLevelTestConnection_InvalidBroker
    client_coverage_test.go:447: Latency should be > 0
--- FAIL: TestTestConnection
```

Both connect to deliberately unreachable brokers and assert `Latency > 0`, but `TestConnection`
truncates the elapsed time to whole milliseconds, so a connection that is refused instantly
reports `0`. They fail the same way on a clean `origin/main` checkout here, and this branch
touches no MQTT code, tests, or dependencies.

`gofmt` clean, `go vet` clean, `golangci-lint run --new-from-rev origin/main`: 0 issues.

## **API Endpoints Tested:**

None directly. The `POST /api/v1/notifications` request schema defines `importance` as an
unconstrained string, so no endpoint signature or schema annotation changed.

- **Test Output/Results:**

```
ok  github.com/ruaan-deysel/unraid-management-agent/daemon/services/controllers
```

**Log Output (if relevant):**

```
(n/a)
```

## Documentation

- [x] Code comments added/updated
- [ ] README.md updated (if needed) — not needed
- [ ] CLAUDE.md updated (if architecture changed) — no architecture change
- [ ] CONTRIBUTING.md updated (if contribution process changed) — n/a
- [ ] API documentation updated — no annotation changed, so nothing to regenerate
- [x] CHANGELOG.md updated (entry under `## [Unreleased]`)

## Breaking Changes

## **Breaking Changes:**

None. `info` remains accepted and written verbatim; `normal` is additive and matches stock
vocabulary. Notification counting already treats `normal` and `info` as the same bucket.

## **Migration Guide:**

None required.

## Screenshots/Logs

N/A — the failing log line is quoted in the issue.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (`golangci-lint --new-from-rev`: 0 issues)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes — with the two `origin/main`
      MQTT failures noted above
- [x] Any dependent changes have been merged and published (n/a — none)
- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] No sensitive information (API keys, passwords, personal data) is included

## Hardware Compatibility Notes

N/A — not a hardware compatibility fix.

## Additional Notes

The dispatcher's severity mapping is untouched, and `info` still produces exactly the same
file it did before.

Three things I noticed but left alone, in case they are useful to you:

- `TestImportanceLevelValidation` and the importance table in
  `notification_additional_test.go` re-implement the old `alert|warning|info` allowlist inline
  rather than calling `CreateNotification`, so they still describe the old behaviour and cannot
  fail either way. After this change they are the last copies of that allow-list in the repo,
  so they are worth deleting or pointing at the real validator — happy to do that if you want
  it in here.
- `POST /api/v1/notifications` turns an invalid importance into a 500, because the handler
  treats every `CreateNotification` error the same way. Now that the check lives in
  `daemon/lib` the handler could call it directly and return 400 instead, but that changes API
  behaviour so it is not in this PR.
- The `Notification` DTO comment (and therefore the generated Swagger description) lists only
  `alert`, `warning`, `info`, though native Unraid notification files have always been able to
  contain `normal`. Updating it would mean regenerating Swagger, so it seemed out of scope
  here.

Thanks!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications now support the `normal` importance level, alongside `alert`, `warning`, and `info`.
  * Information-severity alerts can now be delivered to the `unraid` channel.
  * Notifications using `normal` or `info` importance are saved correctly for both unread and archived views.

* **Bug Fixes**
  * Improved validation messages for unsupported notification importance levels.
  * Prevented invalid notification requests from creating notification files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->